### PR TITLE
Update HTTP client handling in ProcessManager for graceful degradation

### DIFF
--- a/src-tauri/src/process/manager.rs
+++ b/src-tauri/src/process/manager.rs
@@ -169,21 +169,18 @@ impl ProcessManager {
             shutting_down: false,
         }));
 
-        let http_client = match Client::builder()
+        let http_client = Client::builder()
             .timeout(Duration::from_secs(3))
             .no_proxy()
             .build()
-        {
-            Ok(client) => Some(client),
-            Err(e) => {
+            .map_err(|e| {
                 log::error!(
-                    "Failed to create monitor HTTP client (TLS init failure): {}. \
+                    "Failed to create monitor HTTP client: {}. \
                      Health checks will be degraded to liveness-only mode.",
                     e
                 );
-                None
-            }
-        };
+            })
+            .ok();
 
         Self {
             state,

--- a/src-tauri/src/process/monitor.rs
+++ b/src-tauri/src/process/monitor.rs
@@ -121,6 +121,36 @@ async fn evaluate_instances(
     entries: &[LiveSnapshot],
     http_client: Option<&Client>,
 ) -> Vec<MonitorOutcome> {
+    match http_client {
+        Some(client) => evaluate_instances_with_health(entries, client).await,
+        None => evaluate_instances_liveness_only(entries),
+    }
+}
+
+/// Liveness-only evaluation when no HTTP client is available.
+fn evaluate_instances_liveness_only(entries: &[LiveSnapshot]) -> Vec<MonitorOutcome> {
+    let now = Instant::now();
+    let mut outcomes = Vec::new();
+
+    for entry in entries {
+        let Some(outcome) = evaluate_liveness(entry, now) else {
+            outcomes.push(MonitorOutcome::Dead {
+                id: entry.id.clone(),
+            });
+            continue;
+        };
+
+        outcomes.push(outcome);
+    }
+
+    outcomes
+}
+
+/// Full evaluation with concurrent HTTP health checks for dashboard-enabled instances.
+async fn evaluate_instances_with_health(
+    entries: &[LiveSnapshot],
+    http_client: &Client,
+) -> Vec<MonitorOutcome> {
     let now = Instant::now();
     let mut outcomes: Vec<MonitorOutcome> = Vec::new();
     let mut needs_health_check: Vec<(&LiveSnapshot, MonitorOutcome)> = Vec::new();
@@ -139,50 +169,38 @@ async fn evaluate_instances(
             continue;
         }
 
-        match http_client {
-            Some(_) => {
-                // Dashboard enabled: health check will overwrite health fields in outcome.
-                needs_health_check.push((entry, outcome));
-            }
-            None => {
-                // No HTTP client available — skip HTTP health check, use liveness only.
-                outcomes.push(outcome);
-            }
-        }
+        // Dashboard enabled: health check will overwrite health fields in outcome.
+        needs_health_check.push((entry, outcome));
     }
 
-    // Concurrent health checks (inlined — no separate helper function)
-    // needs_health_check is only populated when http_client is Some.
-    if let Some(client) = http_client {
-        let health_futures: Vec<_> = needs_health_check
-            .into_iter()
-            .map(|(entry, outcome)| async move {
-                let (health_failure_count, next_health_check_at) =
-                    evaluate_health(entry, now, client).await;
-                match outcome {
-                    MonitorOutcome::Alive {
-                        id,
-                        alive_failure_count,
-                        next_alive_check_at,
-                        new_pid,
-                        ..
-                    } => MonitorOutcome::Alive {
-                        id,
-                        health_failure_count,
-                        next_health_check_at,
-                        alive_failure_count,
-                        next_alive_check_at,
-                        new_pid,
-                    },
-                    dead @ MonitorOutcome::Dead { .. } => dead,
-                }
-            })
-            .collect();
-        let health_results = futures_util::future::join_all(health_futures).await;
+    // Concurrent health checks
+    let health_futures: Vec<_> = needs_health_check
+        .into_iter()
+        .map(|(entry, outcome)| async move {
+            let (health_failure_count, next_health_check_at) =
+                evaluate_health(entry, now, http_client).await;
+            match outcome {
+                MonitorOutcome::Alive {
+                    id,
+                    alive_failure_count,
+                    next_alive_check_at,
+                    new_pid,
+                    ..
+                } => MonitorOutcome::Alive {
+                    id,
+                    health_failure_count,
+                    next_health_check_at,
+                    alive_failure_count,
+                    next_alive_check_at,
+                    new_pid,
+                },
+                dead @ MonitorOutcome::Dead { .. } => dead,
+            }
+        })
+        .collect();
+    let health_results = futures_util::future::join_all(health_futures).await;
 
-        outcomes.extend(health_results);
-    }
-
+    outcomes.extend(health_results);
     outcomes
 }
 


### PR DESCRIPTION
Enhance the ProcessManager to handle HTTP client initialization failures gracefully, allowing for liveness-only checks when the client is unavailable. This change improves system resilience during health check operations.

## Summary by Sourcery

当无法初始化 HTTP 客户端时，通过将健康检查设为可选并回退为仅存活（liveness-only）监控，使进程监控能够优雅降级。

New Features:
- 当 HTTP 客户端不可用时，允许实例监控以仅存活模式（liveness-only mode）运行。

Enhancements:
- 将 `ProcessManager` 中的监控 HTTP 客户端设为可选，并将这一变化传递到监控逻辑中，以有条件地执行 HTTP 健康检查。
- 在 HTTP 客户端初始化（TLS）失败时记录日志而不是触发 panic，从而使进程监控在没有健康检查的情况下仍能继续运行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Gracefully degrade process monitoring when the HTTP client cannot be initialized by making health checks optional and falling back to liveness-only monitoring.

New Features:
- Allow instance monitoring to run in liveness-only mode when the HTTP client is unavailable.

Enhancements:
- Make the monitor HTTP client in ProcessManager optional and propagate this to monitoring logic to conditionally perform HTTP health checks.
- Log HTTP client initialization (TLS) failures instead of panicking so that process monitoring can continue without health checks.

</details>

新功能：
- 当 HTTP 客户端不可用时，支持在没有 HTTP 健康检查的情况下运行实例监控。

增强项：
- 使 `ProcessManager` 中的 HTTP 客户端变为可选，并将这一点传播到监控逻辑中，以有条件地执行健康检查。
- 记录 HTTP 客户端的 TLS 初始化失败日志，并继续进行进程监控，而不是直接触发 panic。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

当无法初始化 HTTP 客户端时，通过将健康检查设为可选并回退为仅存活（liveness-only）监控，使进程监控能够优雅降级。

New Features:
- 当 HTTP 客户端不可用时，允许实例监控以仅存活模式（liveness-only mode）运行。

Enhancements:
- 将 `ProcessManager` 中的监控 HTTP 客户端设为可选，并将这一变化传递到监控逻辑中，以有条件地执行 HTTP 健康检查。
- 在 HTTP 客户端初始化（TLS）失败时记录日志而不是触发 panic，从而使进程监控在没有健康检查的情况下仍能继续运行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Gracefully degrade process monitoring when the HTTP client cannot be initialized by making health checks optional and falling back to liveness-only monitoring.

New Features:
- Allow instance monitoring to run in liveness-only mode when the HTTP client is unavailable.

Enhancements:
- Make the monitor HTTP client in ProcessManager optional and propagate this to monitoring logic to conditionally perform HTTP health checks.
- Log HTTP client initialization (TLS) failures instead of panicking so that process monitoring can continue without health checks.

</details>

</details>