### PR TITLE
Stop clearing proxy environment variables

### DIFF
--- a/src-tauri/src/component/python.rs
+++ b/src-tauri/src/component/python.rs
@@ -110,10 +110,7 @@ pub async fn pip_install_requirements(
     let proxy_env_vars = match proxy::build_proxy_env_vars(config) {
         Ok(vars) => vars,
         Err(e) => {
-            log::warn!(
-                "Failed to prepare proxy env for pip install, fallback to no proxy: {}",
-                e
-            );
+            log::warn!("Failed to prepare proxy env for pip install: {}", e);
             Vec::new()
         }
     };

--- a/src-tauri/src/utils/proxy.rs
+++ b/src-tauri/src/utils/proxy.rs
@@ -105,12 +105,6 @@ pub(crate) fn build_proxy_env_vars(config: &AppConfig) -> Result<Vec<(OsString, 
 
 pub(crate) fn apply_proxy_env(cmd: &mut Command, env_vars: &[(OsString, OsString)]) {
     if env_vars.is_empty() {
-        for key in PROXY_ENV_KEYS {
-            cmd.env_remove(key);
-        }
-        for key in NO_PROXY_ENV_KEYS {
-            cmd.env_remove(key);
-        }
         return;
     }
 


### PR DESCRIPTION
fixes #25 #24
Eliminate the cleanup of environment variables.

## 由 Sourcery 生成的摘要

在为子进程准备和应用代理设置时，停止清除已有的代理相关环境变量。

错误修复：
- 在未构建任何代理配置时，保留现有的代理和 no-proxy 环境变量，而不是将其删除。

改进：
- 当代理环境准备失败时，明确警告日志信息，以反映未应用显式的 no-proxy 回退策略。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Stop clearing existing proxy-related environment variables when preparing and applying proxy settings for subprocesses.

Bug Fixes:
- Preserve existing proxy and no-proxy environment variables instead of removing them when no proxy configuration is built.

Enhancements:
- Clarify warning log message when proxy environment preparation fails to reflect that no explicit no-proxy fallback is applied.

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 生成的摘要

在为子进程准备和应用代理设置时，停止清除已有的代理相关环境变量。

错误修复：
- 在未构建任何代理配置时，保留现有的代理和 no-proxy 环境变量，而不是将其删除。

改进：
- 当代理环境准备失败时，明确警告日志信息，以反映未应用显式的 no-proxy 回退策略。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Stop clearing existing proxy-related environment variables when preparing and applying proxy settings for subprocesses.

Bug Fixes:
- Preserve existing proxy and no-proxy environment variables instead of removing them when no proxy configuration is built.

Enhancements:
- Clarify warning log message when proxy environment preparation fails to reflect that no explicit no-proxy fallback is applied.

</details>

</details>