### PR TITLE
Add DOMPurify for HTML sanitization

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@tauri-apps/plugin-window-state": "~2.4.1",
     "ansi-to-react": "^6.2.6",
     "antd": "^6.3.4",
+    "dompurify": "^3.3.3",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-markdown": "^10.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       antd:
         specifier: ^6.3.4
         version: 6.3.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      dompurify:
+        specifier: ^3.3.3
+        version: 3.3.3
       react:
         specifier: ^19.2.4
         version: 19.2.4
@@ -1015,6 +1018,9 @@ packages:
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
@@ -1307,6 +1313,9 @@ packages:
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
+
+  dompurify@3.3.3:
+    resolution: {integrity: sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -3230,6 +3239,9 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
@@ -3626,6 +3638,10 @@ snapshots:
   doctrine@2.1.0:
     dependencies:
       esutils: 2.0.3
+
+  dompurify@3.3.3:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   dunder-proto@1.0.1:
     dependencies:

--- a/src/components/MarkdownContent.tsx
+++ b/src/components/MarkdownContent.tsx
@@ -1,6 +1,7 @@
 import type { CSSProperties, ReactNode } from 'react';
 import ReactMarkdown from 'react-markdown';
 import { theme } from 'antd';
+import { sanitizeUrl } from '../utils';
 
 interface MarkdownContentProps {
   children?: string | null;
@@ -31,11 +32,16 @@ export function MarkdownContent({ children, containerStyle, fallback }: Markdown
             h1: ({ children: c }) => <h3 style={{ marginBottom: 4 }}>{c}</h3>,
             h2: ({ children: c }) => <h4 style={{ marginBottom: 4 }}>{c}</h4>,
             h3: ({ children: c }) => <strong style={{ display: 'block', marginTop: 8, marginBottom: 2 }}>{c}</strong>,
-            a: ({ href, children: c }) => (
-              <a href={href} target="_blank" rel="noreferrer noopener" style={{ color: token.colorPrimary }}>
-                {c}
-              </a>
-            ),
+            a: ({ href, children: c }) => {
+              const safeHref = sanitizeUrl(href);
+              return safeHref ? (
+                <a href={safeHref} target="_blank" rel="noreferrer noopener" style={{ color: token.colorPrimary }}>
+                  {c}
+                </a>
+              ) : (
+                <span>{c}</span>
+              );
+            },
             p: ({ children: c }) => <p style={{ margin: '2px 0' }}>{c}</p>,
             ul: ({ children: c }) => <ul style={{ paddingLeft: 20, margin: '4px 0' }}>{c}</ul>,
             li: ({ children: c }) => <li style={{ marginBottom: 2 }}>{c}</li>,

--- a/src/pages/Logs.tsx
+++ b/src/pages/Logs.tsx
@@ -4,6 +4,7 @@ import { ClearOutlined } from '@ant-design/icons';
 import Ansi from 'ansi-to-react';
 import { PageHeader } from '../components';
 import { useAppStore, useLogStore, type LogLevelFilter } from '../stores';
+import { sanitizeHtml } from '../utils';
 
 const { Content } = Layout;
 
@@ -117,7 +118,7 @@ export default function Logs() {
             <Flex vertical gap={0}>
               {logs.map((entry, i) => (
                 <div key={`${entry.timestamp}-${i}`}>
-                  <Ansi>{entry.message}</Ansi>
+                  <Ansi>{sanitizeHtml(entry.message)}</Ansi>
                 </div>
               ))}
             </Flex>

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,2 +1,3 @@
 export { getErrorMessage, handleApiError } from './error';
 export { isInstanceDeploying } from './deploy';
+export { sanitizeHtml, sanitizeUrl } from './sanitize';

--- a/src/utils/sanitize.ts
+++ b/src/utils/sanitize.ts
@@ -1,0 +1,23 @@
+import DOMPurify from 'dompurify';
+
+const SAFE_URL_PROTOCOLS = /^(?:https?|mailto):/i;
+
+/**
+ * Sanitize an HTML string, stripping all dangerous tags and attributes.
+ */
+export function sanitizeHtml(dirty: string): string {
+  return DOMPurify.sanitize(dirty);
+}
+
+/**
+ * Return the URL unchanged when it uses a safe protocol (`http:`, `https:`,
+ * `mailto:`) or is a relative/anchor path.  Returns an empty string for
+ * dangerous schemes such as `javascript:` or `data:`.
+ */
+export function sanitizeUrl(url: string | undefined): string {
+  if (!url) return '';
+  const trimmed = url.trim();
+  if (trimmed === '' || trimmed.startsWith('#') || trimmed.startsWith('/')) return trimmed;
+  if (SAFE_URL_PROTOCOLS.test(trimmed)) return trimmed;
+  return '';
+}


### PR DESCRIPTION
Introduce DOMPurify for sanitizing HTML content in the MarkdownContent and Logs components, enhancing security by preventing XSS attacks. Update components to utilize the new sanitization functions.

## Summary by Sourcery

Introduce centralized HTML and URL sanitization utilities and apply them to user-facing Markdown and log rendering to improve XSS protection.

New Features:
- Add sanitizeHtml and sanitizeUrl utility functions built on DOMPurify for safe HTML and URL handling.

Enhancements:
- Update MarkdownContent links to use sanitized URLs and fall back to plain text when URLs are unsafe.
- Sanitize log messages before rendering ANSI-formatted output in the Logs page.

Build:
- Add dompurify as a new runtime dependency.