### PR TITLE
Implement lock check modal flow for backup and instance operations

### DIFF
--- a/src-tauri/src/backup.rs
+++ b/src-tauri/src/backup.rs
@@ -13,7 +13,6 @@ use crate::archive::{extract_tar_gz_mapped, extract_zip_mapped};
 use crate::config::{load_manifest, with_manifest_mut, BackupInfo, BackupMetadata, InstanceConfig};
 use crate::error::{AppError, Result};
 use crate::utils::archive_path::parse_entry_rel_path;
-use crate::utils::lock_check::{collect_files_for_lock_check, ensure_target_not_locked};
 use crate::utils::paths::{get_backups_dir, get_instance_core_dir, get_instance_dir};
 use crate::utils::validation::validate_instance_id;
 use crate::validation::resolve_backup_path;
@@ -158,8 +157,6 @@ pub fn create_backup(instance_id: &str, auto_generated: bool) -> Result<String> 
     if !data_dir.exists() {
         return Err(AppError::backup("No data directory to back up"));
     }
-    let data_files = collect_files_for_lock_check(&data_dir)?;
-    ensure_target_not_locked(&data_files)?;
 
     create_backup_archive(instance, instance_id, auto_generated)
 }
@@ -396,6 +393,7 @@ pub fn resolve_restore_backup_input(backup_path: &str) -> Result<(PathBuf, Backu
     Ok((backup_path, metadata))
 }
 
+/// Restore backup.
 pub fn restore_backup_with_input(backup_path: PathBuf, metadata: BackupMetadata) -> Result<()> {
     // Check if version is installed
     let manifest = load_manifest()?;
@@ -415,9 +413,6 @@ pub fn restore_backup_with_input(backup_path: PathBuf, metadata: BackupMetadata)
 
     let instance_dir = get_instance_dir(instance_id);
     let core_dir = get_instance_core_dir(instance_id);
-    let data_dir = core_dir.join("data");
-    let data_files = collect_files_for_lock_check(&data_dir)?;
-    ensure_target_not_locked(&data_files)?;
 
     // Extract backup to existing instance
     extract_backup_to_instance(&backup_path, &instance_dir, &core_dir)?;
@@ -498,9 +493,6 @@ pub fn restore_data_to_instance(backup_path: &str, instance_id: &str) -> Result<
     let backup_path = resolve_backup_path(backup_path, true)?;
     let metadata = read_backup_metadata(&backup_path)?;
     let core_dir = get_instance_core_dir(instance_id);
-    let data_dir = core_dir.join("data");
-    let data_files = collect_files_for_lock_check(&data_dir)?;
-    ensure_target_not_locked(&data_files)?;
 
     let routing = |raw_path: &str| -> Option<PathBuf> {
         let relative = parse_entry_rel_path(raw_path)?;

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -19,11 +19,14 @@ use crate::network_config;
 use crate::platform;
 use crate::process::ProcessManager;
 use crate::utils::index_url::normalize_default_index;
+use crate::utils::lock_check::{collect_files_for_lock_check, ensure_target_not_locked};
 use crate::utils::net::{build_http_client_with_proxy, check_url};
+use crate::utils::paths::get_instance_core_dir;
 use crate::utils::proxy::{
     build_single_url_proxy_settings, ProxyFields, ProxySource, DEFAULT_NO_PROXY_VALUE,
 };
 use crate::utils::sync::{read_lock_recover, write_lock_recover};
+use crate::utils::validation::validate_instance_id;
 
 fn sort_installed_versions_semver(versions: &mut [InstalledVersion]) {
     versions.sort_by(|a, b| {
@@ -378,6 +381,50 @@ pub async fn uninstall_version(version: String) -> Result<()> {
 }
 
 // === Troubleshooting ===
+
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LockCheckTarget {
+    InstanceData,
+    BackupCreate,
+    BackupRestore,
+    InstanceUpgrade,
+}
+
+fn run_instance_data_lock_check(instance_id: &str) -> Result<()> {
+    validate_instance_id(instance_id)?;
+    let data_dir = get_instance_core_dir(instance_id).join("data");
+    let target_files = collect_files_for_lock_check(&data_dir)?;
+    ensure_target_not_locked(&target_files)
+}
+
+#[tauri::command]
+pub async fn check_lock(
+    target: LockCheckTarget,
+    instance_id: Option<String>,
+    backup_path: Option<String>,
+    state: State<'_, AppState>,
+) -> Result<()> {
+    match target {
+        LockCheckTarget::InstanceData
+        | LockCheckTarget::BackupCreate
+        | LockCheckTarget::InstanceUpgrade => {
+            let instance_id = instance_id
+                .as_deref()
+                .ok_or_else(|| AppError::other("check_lock 缺少 instance_id"))?;
+            let _guard = state.process_manager.acquire_guard(instance_id)?;
+            run_instance_data_lock_check(instance_id)
+        }
+        LockCheckTarget::BackupRestore => {
+            let backup_path = backup_path
+                .as_deref()
+                .ok_or_else(|| AppError::other("check_lock 缺少 backup_path"))?;
+            let (_, metadata) = backup::resolve_restore_backup_input(backup_path)?;
+            let _guard = state.process_manager.acquire_guard(&metadata.instance_id)?;
+            run_instance_data_lock_check(&metadata.instance_id)
+        }
+    }
+}
 
 #[tauri::command]
 pub async fn clear_instance_data(instance_id: String, state: State<'_, AppState>) -> Result<()> {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -394,6 +394,9 @@ pub enum LockCheckTarget {
 fn run_instance_data_lock_check(instance_id: &str) -> Result<()> {
     validate_instance_id(instance_id)?;
     let data_dir = get_instance_core_dir(instance_id).join("data");
+    if !data_dir.exists() {
+        return Ok(());
+    }
     let target_files = collect_files_for_lock_check(&data_dir)?;
     ensure_target_not_locked(&target_files)
 }

--- a/src-tauri/src/instance/cleanup.rs
+++ b/src-tauri/src/instance/cleanup.rs
@@ -5,7 +5,6 @@ use std::path::Path;
 use walkdir::WalkDir;
 
 use crate::error::{AppError, Result};
-use crate::utils::lock_check::{collect_files_for_lock_check, ensure_target_not_locked};
 use crate::utils::paths::{get_instance_core_dir, get_instance_venv_dir};
 use crate::utils::validation::validate_instance_id;
 
@@ -17,8 +16,6 @@ pub fn clear_instance_data(instance_id: &str) -> Result<()> {
     let data_dir = core_dir.join("data");
 
     if data_dir.exists() {
-        let target_files = collect_files_for_lock_check(&data_dir)?;
-        ensure_target_not_locked(&target_files)?;
         std::fs::remove_dir_all(&data_dir)
             .map_err(|e| AppError::io(format!("Failed to clear data: {}", e)))?;
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -133,6 +133,7 @@ pub fn run() {
             commands::install_version,
             commands::uninstall_version,
             // Troubleshooting
+            commands::check_lock,
             commands::clear_instance_data,
             commands::clear_instance_venv,
             commands::clear_pycache,

--- a/src-tauri/src/utils/lock_check.rs
+++ b/src-tauri/src/utils/lock_check.rs
@@ -1,8 +1,9 @@
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
-#[cfg(target_os = "windows")]
-use crate::error::AppError;
 use crate::error::Result;
+#[cfg(target_os = "windows")]
+use crate::error::{AppError, ErrorKind};
 #[cfg(target_os = "windows")]
 use crate::process::win_api::{
     get_processes_locking_files, LockingProcessInfo, RestartManagerQueryError,
@@ -96,14 +97,32 @@ fn format_locking_process(process: &LockingProcessInfo) -> String {
 /// Single batch Restart Manager query for all files.
 #[cfg(target_os = "windows")]
 pub(crate) fn ensure_target_not_locked(target_files: &[PathBuf]) -> Result<()> {
-    let locking_processes = get_processes_locking_files(target_files).map_err(|e| {
-        log::warn!("Failed to query locking processes: {}", e);
-        if matches!(e, RestartManagerQueryError::MaxSessionsReached) {
-            AppError::process_locking("系统 Restart Manager 会话数已达上限")
-        } else {
-            AppError::process_locking("目标路径占用状态检测失败")
+    let locking_processes = match get_processes_locking_files(target_files) {
+        Ok(locking_processes) => locking_processes,
+        Err(e) => {
+            log::warn!("Failed to query locking processes: {}", e);
+            let detail = if matches!(e, RestartManagerQueryError::MaxSessionsReached) {
+                "系统 Restart Manager 会话数已达上限，无法检测占用状态"
+            } else {
+                "目标路径占用状态检测失败"
+            };
+
+            let mut payload = HashMap::from([
+                ("detail".to_string(), detail.to_string()),
+                ("reason".to_string(), "check_failed".to_string()),
+                ("can_continue".to_string(), "true".to_string()),
+                ("query_error".to_string(), e.to_string()),
+            ]);
+            if matches!(e, RestartManagerQueryError::MaxSessionsReached) {
+                payload.insert(
+                    "check_failure_kind".to_string(),
+                    "max_sessions_reached".to_string(),
+                );
+            }
+
+            return Err(AppError::new(ErrorKind::ProcessLocking, payload));
         }
-    })?;
+    };
     if locking_processes.is_empty() {
         return Ok(());
     }
@@ -113,8 +132,20 @@ pub(crate) fn ensure_target_not_locked(target_files: &[PathBuf]) -> Result<()> {
         .map(format_locking_process)
         .collect();
     log::warn!("Target files are locked by: {}", process_items.join("；"));
-    Err(AppError::process_locking(
-        "目标路径被占用，请关闭相关进程后重试，请前往日志页面查看详情。",
+    Err(AppError::new(
+        ErrorKind::ProcessLocking,
+        HashMap::from([
+            (
+                "detail".to_string(),
+                "目标路径被占用，请关闭相关进程后重试".to_string(),
+            ),
+            ("reason".to_string(), "locked".to_string()),
+            ("can_continue".to_string(), "false".to_string()),
+            (
+                "locking_processes".to_string(),
+                serde_json::to_string(&process_items).unwrap_or_else(|_| "[]".to_string()),
+            ),
+        ]),
     ))
 }
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,6 +1,16 @@
 import { invoke } from '@tauri-apps/api/core';
 import type { GitHubRelease, AppSnapshot } from './types';
 
+type LockCheckRequest =
+  | {
+      target: 'instance_data' | 'backup_create' | 'instance_upgrade';
+      instanceId: string;
+    }
+  | {
+      target: 'backup_restore';
+      backupPath: string;
+    };
+
 export const api = {
   // ========================================
   // Snapshot
@@ -61,6 +71,12 @@ export const api = {
   // Troubleshooting
   // ========================================
   clearInstanceData: (instanceId: string) => invoke<void>('clear_instance_data', { instanceId }),
+  checkLock: (request: LockCheckRequest) =>
+    invoke<void>('check_lock', {
+      target: request.target,
+      instanceId: 'instanceId' in request ? request.instanceId : null,
+      backupPath: 'backupPath' in request ? request.backupPath : null,
+    }),
   clearInstanceVenv: (instanceId: string) => invoke<void>('clear_instance_venv', { instanceId }),
   clearPycache: (instanceId: string) => invoke<void>('clear_pycache', { instanceId }),
 

--- a/src/components/LockCheckConfirmModal.tsx
+++ b/src/components/LockCheckConfirmModal.tsx
@@ -1,0 +1,52 @@
+import { ConfirmModal } from './ConfirmModal';
+import type { LockCheckModalState } from '../hooks/useLockCheckModal';
+
+type LockCheckConfirmModalProps<TPayload> = {
+  state: LockCheckModalState<TPayload> | null;
+  loading?: boolean;
+  onContinue: (payload: TPayload) => void | Promise<void>;
+  onClose: () => void;
+};
+
+export function LockCheckConfirmModal<TPayload>({
+  state,
+  loading = false,
+  onContinue,
+  onClose,
+}: LockCheckConfirmModalProps<TPayload>) {
+  return (
+    <ConfirmModal
+      open={state !== null}
+      title={state?.mode === 'locked' ? '目标路径被占用' : '目标路径占用检测失败'}
+      danger={state?.mode === 'locked'}
+      okText={state?.mode === 'checkFailed' ? '继续操作' : '我知道了'}
+      loading={loading}
+      content={
+        <>
+          <p>{state?.detail}</p>
+          {state?.lockingProcesses?.length ? (
+            <div>
+              <p>检测到以下进程正在占用目标路径:</p>
+              {state.lockingProcesses.map((process, index) => (
+                <p key={`${process}-${index}`}>
+                  {index + 1}. {process}
+                </p>
+              ))}
+            </div>
+          ) : null}
+          {state?.mode === 'checkFailed' ? (
+            <p>可选择继续执行本次操作，或取消后稍后重试。</p>
+          ) : (
+            <p>请关闭相关进程后重试。</p>
+          )}
+        </>
+      }
+      onConfirm={
+        state?.mode === 'checkFailed'
+          ? () => void onContinue(state.payload)
+          : onClose
+      }
+      onCancel={onClose}
+    />
+  );
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -4,6 +4,7 @@ export { InstanceStatusTag } from './InstanceStatusTag';
 export { InstanceActions } from './InstanceActions';
 export { DeployProgressModal } from './DeployProgressModal';
 export { ConfirmModal } from './ConfirmModal';
+export { LockCheckConfirmModal } from './LockCheckConfirmModal';
 export { EditInstanceModal } from './EditInstanceModal';
 export { ErrorBoundary } from './ErrorBoundary';
 export { TitleBar } from './TitleBar';

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,2 +1,3 @@
 export { useOperationRunner, SKIP_OPERATION } from './useOperationRunner';
 export { findLatestOrSkip } from './operationGuards';
+export { useLockCheckModal } from './useLockCheckModal';

--- a/src/hooks/useLockCheckModal.ts
+++ b/src/hooks/useLockCheckModal.ts
@@ -1,0 +1,59 @@
+import { useCallback, useState } from 'react';
+import { parseProcessLockingError } from '../utils';
+
+type LockCheckModalBase = {
+  detail: string;
+  lockingProcesses: string[];
+};
+
+export type LockCheckModalState<TPayload> =
+  | ({ mode: 'checkFailed'; payload: TPayload } & LockCheckModalBase)
+  | ({ mode: 'locked' } & LockCheckModalBase);
+
+type HandleLockCheckErrorOptions<TPayload> = {
+  checkFailedPayload: TPayload;
+  onLockCheckError?: (mode: 'checkFailed' | 'locked') => void;
+};
+
+export function useLockCheckModal<TPayload>() {
+  const [lockCheckModal, setLockCheckModal] = useState<LockCheckModalState<TPayload> | null>(null);
+
+  const closeLockCheckModal = useCallback(() => {
+    setLockCheckModal(null);
+  }, []);
+
+  const handleLockCheckError = useCallback(
+    (error: unknown, options: HandleLockCheckErrorOptions<TPayload>): boolean => {
+      const lockCheckError = parseProcessLockingError(error);
+      if (!lockCheckError) {
+        return false;
+      }
+
+      const mode = lockCheckError.canContinue ? 'checkFailed' : 'locked';
+      options.onLockCheckError?.(mode);
+      if (mode === 'checkFailed') {
+        setLockCheckModal({
+          mode,
+          payload: options.checkFailedPayload,
+          detail: lockCheckError.detail,
+          lockingProcesses: lockCheckError.lockingProcesses,
+        });
+      } else {
+        setLockCheckModal({
+          mode,
+          detail: lockCheckError.detail,
+          lockingProcesses: lockCheckError.lockingProcesses,
+        });
+      }
+      return true;
+    },
+    []
+  );
+
+  return {
+    lockCheckModal,
+    setLockCheckModal,
+    closeLockCheckModal,
+    handleLockCheckError,
+  };
+}

--- a/src/pages/Advanced.tsx
+++ b/src/pages/Advanced.tsx
@@ -3,16 +3,17 @@ import { enable, disable, isEnabled } from '@tauri-apps/plugin-autostart';
 import { api } from '../api';
 import { message } from '../antdStatic';
 import { useAppStore } from '../stores';
-import { SKIP_OPERATION, findLatestOrSkip, useOperationRunner } from '../hooks';
+import { SKIP_OPERATION, findLatestOrSkip, useLockCheckModal, useOperationRunner } from '../hooks';
 import {
   ConfirmModal,
   GeneralSettingsCard,
+  LockCheckConfirmModal,
   ProxySettingsCard,
   SourceSettingsCard,
   TroubleshootingCard,
   PageHeader,
 } from '../components';
-import { handleApiError, parseProcessLockingError } from '../utils';
+import { handleApiError } from '../utils';
 import { OPERATION_KEYS } from '../constants';
 import {
   normalizeInputValue,
@@ -50,19 +51,10 @@ type SourceSettingConfig = {
   reloadBefore?: boolean;
 };
 type ClearActionType = Exclude<ConfirmModalType, null>;
-type LockCheckModalState =
-  | {
-      mode: 'checkFailed';
-      clearType: ClearActionType;
-      instanceId: string;
-      detail: string;
-      lockingProcesses: string[];
-    }
-  | {
-      mode: 'locked';
-      detail: string;
-      lockingProcesses: string[];
-    };
+type LockCheckRetryPayload = {
+  retry: () => Promise<void>;
+  operationKey: string;
+};
 
 export default function Advanced() {
   const instances = useAppStore((s) => s.instances);
@@ -97,7 +89,8 @@ export default function Advanced() {
 
   // Modal state
   const [confirmModal, setConfirmModal] = useState<ConfirmModalType>(null);
-  const [lockCheckModal, setLockCheckModal] = useState<LockCheckModalState | null>(null);
+  const { lockCheckModal, closeLockCheckModal, handleLockCheckError } =
+    useLockCheckModal<LockCheckRetryPayload>();
 
   // Autostart state
   const [autostart, setAutostart] = useState(false);
@@ -330,7 +323,6 @@ export default function Advanced() {
   };
 
   const handleClearInstance = async ({
-    clearType,
     selectedId,
     operationKey,
     clearSelection,
@@ -339,16 +331,12 @@ export default function Advanced() {
     successMessage,
     requireStoppedMessage,
     skipLockCheck = false,
-    selectedIdOverride,
   }: ClearInstanceOptions & {
-    clearType: ClearActionType;
     skipLockCheck?: boolean;
-    selectedIdOverride?: string;
   }) => {
-    const selectedIdForRun = selectedIdOverride ?? selectedId;
-    if (!selectedIdForRun) return;
+    if (!selectedId) return;
 
-    const key = operationKey(selectedIdForRun);
+    const key = operationKey(selectedId);
     await runOperation({
       key,
       reloadBefore: true,
@@ -356,7 +344,7 @@ export default function Advanced() {
         const { instances: latestInstances } = useAppStore.getState();
         const latestInstance = findLatestOrSkip(
           latestInstances,
-          (i) => i.id === selectedIdForRun,
+          (i) => i.id === selectedId,
           '实例不存在或已被删除'
         );
         if (latestInstance === SKIP_OPERATION) {
@@ -371,41 +359,42 @@ export default function Advanced() {
         }
 
         if (!skipLockCheck && checkAction) {
-          await checkAction(selectedIdForRun);
+          await checkAction(selectedId);
         }
 
-        await clearAction(selectedIdForRun);
+        await clearAction(selectedId);
       },
       onSuccess: () => {
         message.success(successMessage);
         clearSelection();
         setConfirmModal(null);
-        setLockCheckModal(null);
+        closeLockCheckModal();
       },
       onError: (error) => {
-        const lockCheckError = parseProcessLockingError(error);
-        if (!lockCheckError) {
-          handleApiError(error);
-          return;
-        }
-
-        setConfirmModal(null);
-        if (lockCheckError.canContinue) {
-          setLockCheckModal({
-            mode: 'checkFailed',
-            clearType,
-            instanceId: selectedIdForRun,
-            detail: lockCheckError.detail,
-            lockingProcesses: lockCheckError.lockingProcesses,
-          });
-          return;
-        }
-
-        setLockCheckModal({
-          mode: 'locked',
-          detail: lockCheckError.detail,
-          lockingProcesses: lockCheckError.lockingProcesses,
+        const handled = handleLockCheckError(error, {
+          checkFailedPayload: {
+            operationKey: key,
+            retry: async () => {
+              await handleClearInstance({
+                selectedId,
+                operationKey,
+                clearSelection,
+                checkAction,
+                clearAction,
+                successMessage,
+                requireStoppedMessage,
+                skipLockCheck: true,
+              });
+            },
+          },
+          onLockCheckError: () => {
+            setConfirmModal(null);
+          },
         });
+
+        if (!handled) {
+          handleApiError(error);
+        }
       },
     });
   };
@@ -438,17 +427,11 @@ export default function Advanced() {
   };
 
   const handleClearByType = async (type: ClearActionType) => {
-    await handleClearInstance({ ...clearActionConfigs[type], clearType: type });
+    await handleClearInstance(clearActionConfigs[type]);
   };
 
-  const handleContinueAfterLockCheckFailure = async () => {
-    if (!lockCheckModal || lockCheckModal.mode !== 'checkFailed') return;
-    await handleClearInstance({
-      ...clearActionConfigs[lockCheckModal.clearType],
-      clearType: lockCheckModal.clearType,
-      selectedIdOverride: lockCheckModal.instanceId,
-      skipLockCheck: true,
-    });
+  const handleContinueAfterLockCheckFailure = async (payload: LockCheckRetryPayload) => {
+    await payload.retry();
   };
 
   const instanceOptions = instances.map((i) => ({
@@ -479,9 +462,7 @@ export default function Advanced() {
     operations[OPERATION_KEYS.advancedSaveLockCheckExtensionWhitelist] || false;
   const lockCheckModalLoading =
     lockCheckModal?.mode === 'checkFailed'
-      ? operations[
-          clearActionConfigs[lockCheckModal.clearType].operationKey(lockCheckModal.instanceId)
-        ] || false
+      ? operations[lockCheckModal.payload.operationKey] || false
       : false;
 
   const getConfirmLoading = () => {
@@ -628,38 +609,11 @@ export default function Advanced() {
         onCancel={() => setConfirmModal(null)}
       />
 
-      <ConfirmModal
-        open={lockCheckModal !== null}
-        title={lockCheckModal?.mode === 'locked' ? '目标路径被占用' : '目标路径占用检测失败'}
-        danger={lockCheckModal?.mode === 'locked'}
-        okText={lockCheckModal?.mode === 'checkFailed' ? '继续操作' : '我知道了'}
-        content={
-          <>
-            <p>{lockCheckModal?.detail}</p>
-            {lockCheckModal?.lockingProcesses?.length ? (
-              <div>
-                <p>检测到以下进程正在占用目标路径:</p>
-                {lockCheckModal.lockingProcesses.map((process, index) => (
-                  <p key={`${process}-${index}`}>
-                    {index + 1}. {process}
-                  </p>
-                ))}
-              </div>
-            ) : null}
-            {lockCheckModal?.mode === 'checkFailed' ? (
-              <p>可选择继续执行本次操作，或取消后稍后重试。</p>
-            ) : (
-              <p>请关闭相关进程后重试。</p>
-            )}
-          </>
-        }
+      <LockCheckConfirmModal
+        state={lockCheckModal}
         loading={lockCheckModalLoading}
-        onConfirm={
-          lockCheckModal?.mode === 'checkFailed'
-            ? () => void handleContinueAfterLockCheckFailure()
-            : () => setLockCheckModal(null)
-        }
-        onCancel={() => setLockCheckModal(null)}
+        onContinue={handleContinueAfterLockCheckFailure}
+        onClose={closeLockCheckModal}
       />
     </>
   );

--- a/src/pages/Advanced.tsx
+++ b/src/pages/Advanced.tsx
@@ -12,7 +12,7 @@ import {
   TroubleshootingCard,
   PageHeader,
 } from '../components';
-import { handleApiError } from '../utils';
+import { handleApiError, parseProcessLockingError } from '../utils';
 import { OPERATION_KEYS } from '../constants';
 import {
   normalizeInputValue,
@@ -35,6 +35,7 @@ type ClearInstanceOptions = {
   selectedId: string | null;
   operationKey: (id: string) => string;
   clearSelection: () => void;
+  checkAction?: (id: string) => Promise<void>;
   clearAction: (id: string) => Promise<void>;
   successMessage: string;
   requireStoppedMessage?: string;
@@ -49,6 +50,19 @@ type SourceSettingConfig = {
   reloadBefore?: boolean;
 };
 type ClearActionType = Exclude<ConfirmModalType, null>;
+type LockCheckModalState =
+  | {
+      mode: 'checkFailed';
+      clearType: ClearActionType;
+      instanceId: string;
+      detail: string;
+      lockingProcesses: string[];
+    }
+  | {
+      mode: 'locked';
+      detail: string;
+      lockingProcesses: string[];
+    };
 
 export default function Advanced() {
   const instances = useAppStore((s) => s.instances);
@@ -83,6 +97,7 @@ export default function Advanced() {
 
   // Modal state
   const [confirmModal, setConfirmModal] = useState<ConfirmModalType>(null);
+  const [lockCheckModal, setLockCheckModal] = useState<LockCheckModalState | null>(null);
 
   // Autostart state
   const [autostart, setAutostart] = useState(false);
@@ -315,16 +330,25 @@ export default function Advanced() {
   };
 
   const handleClearInstance = async ({
+    clearType,
     selectedId,
     operationKey,
     clearSelection,
+    checkAction,
     clearAction,
     successMessage,
     requireStoppedMessage,
-  }: ClearInstanceOptions) => {
-    if (!selectedId) return;
+    skipLockCheck = false,
+    selectedIdOverride,
+  }: ClearInstanceOptions & {
+    clearType: ClearActionType;
+    skipLockCheck?: boolean;
+    selectedIdOverride?: string;
+  }) => {
+    const selectedIdForRun = selectedIdOverride ?? selectedId;
+    if (!selectedIdForRun) return;
 
-    const key = operationKey(selectedId);
+    const key = operationKey(selectedIdForRun);
     await runOperation({
       key,
       reloadBefore: true,
@@ -332,7 +356,7 @@ export default function Advanced() {
         const { instances: latestInstances } = useAppStore.getState();
         const latestInstance = findLatestOrSkip(
           latestInstances,
-          (i) => i.id === selectedId,
+          (i) => i.id === selectedIdForRun,
           '实例不存在或已被删除'
         );
         if (latestInstance === SKIP_OPERATION) {
@@ -346,12 +370,42 @@ export default function Advanced() {
           return SKIP_OPERATION;
         }
 
-        await clearAction(selectedId);
+        if (!skipLockCheck && checkAction) {
+          await checkAction(selectedIdForRun);
+        }
+
+        await clearAction(selectedIdForRun);
       },
       onSuccess: () => {
         message.success(successMessage);
         clearSelection();
         setConfirmModal(null);
+        setLockCheckModal(null);
+      },
+      onError: (error) => {
+        const lockCheckError = parseProcessLockingError(error);
+        if (!lockCheckError) {
+          handleApiError(error);
+          return;
+        }
+
+        setConfirmModal(null);
+        if (lockCheckError.canContinue) {
+          setLockCheckModal({
+            mode: 'checkFailed',
+            clearType,
+            instanceId: selectedIdForRun,
+            detail: lockCheckError.detail,
+            lockingProcesses: lockCheckError.lockingProcesses,
+          });
+          return;
+        }
+
+        setLockCheckModal({
+          mode: 'locked',
+          detail: lockCheckError.detail,
+          lockingProcesses: lockCheckError.lockingProcesses,
+        });
       },
     });
   };
@@ -361,7 +415,8 @@ export default function Advanced() {
       selectedId: selectedDataInstance,
       operationKey: OPERATION_KEYS.advancedClearData,
       clearSelection: () => setSelectedDataInstance(null),
-      clearAction: api.clearInstanceData,
+      checkAction: (id) => api.checkLock({ target: 'instance_data', instanceId: id }),
+      clearAction: (id) => api.clearInstanceData(id),
       successMessage: '数据已清空',
       requireStoppedMessage: '请先停止实例再清空数据',
     },
@@ -369,7 +424,7 @@ export default function Advanced() {
       selectedId: selectedVenvInstance,
       operationKey: OPERATION_KEYS.advancedClearVenv,
       clearSelection: () => setSelectedVenvInstance(null),
-      clearAction: api.clearInstanceVenv,
+      clearAction: (id) => api.clearInstanceVenv(id),
       successMessage: '虚拟环境已清空',
       requireStoppedMessage: '请先停止实例再清空虚拟环境',
     },
@@ -377,13 +432,23 @@ export default function Advanced() {
       selectedId: selectedPycacheInstance,
       operationKey: OPERATION_KEYS.advancedClearPycache,
       clearSelection: () => setSelectedPycacheInstance(null),
-      clearAction: api.clearPycache,
+      clearAction: (id) => api.clearPycache(id),
       successMessage: 'Python 缓存已清空',
     },
   };
 
   const handleClearByType = async (type: ClearActionType) => {
-    await handleClearInstance(clearActionConfigs[type]);
+    await handleClearInstance({ ...clearActionConfigs[type], clearType: type });
+  };
+
+  const handleContinueAfterLockCheckFailure = async () => {
+    if (!lockCheckModal || lockCheckModal.mode !== 'checkFailed') return;
+    await handleClearInstance({
+      ...clearActionConfigs[lockCheckModal.clearType],
+      clearType: lockCheckModal.clearType,
+      selectedIdOverride: lockCheckModal.instanceId,
+      skipLockCheck: true,
+    });
   };
 
   const instanceOptions = instances.map((i) => ({
@@ -412,6 +477,12 @@ export default function Advanced() {
     operations[OPERATION_KEYS.advancedSaveIgnoreExternalPath] || false;
   const lockCheckExtensionWhitelistSaving =
     operations[OPERATION_KEYS.advancedSaveLockCheckExtensionWhitelist] || false;
+  const lockCheckModalLoading =
+    lockCheckModal?.mode === 'checkFailed'
+      ? operations[
+          clearActionConfigs[lockCheckModal.clearType].operationKey(lockCheckModal.instanceId)
+        ] || false
+      : false;
 
   const getConfirmLoading = () => {
     switch (confirmModal) {
@@ -555,6 +626,40 @@ export default function Advanced() {
         loading={getConfirmLoading()}
         onConfirm={modalConfig?.onOk ?? (() => {})}
         onCancel={() => setConfirmModal(null)}
+      />
+
+      <ConfirmModal
+        open={lockCheckModal !== null}
+        title={lockCheckModal?.mode === 'locked' ? '目标路径被占用' : '目标路径占用检测失败'}
+        danger={lockCheckModal?.mode === 'locked'}
+        okText={lockCheckModal?.mode === 'checkFailed' ? '继续操作' : '我知道了'}
+        content={
+          <>
+            <p>{lockCheckModal?.detail}</p>
+            {lockCheckModal?.lockingProcesses?.length ? (
+              <div>
+                <p>检测到以下进程正在占用目标路径:</p>
+                {lockCheckModal.lockingProcesses.map((process, index) => (
+                  <p key={`${process}-${index}`}>
+                    {index + 1}. {process}
+                  </p>
+                ))}
+              </div>
+            ) : null}
+            {lockCheckModal?.mode === 'checkFailed' ? (
+              <p>可选择继续执行本次操作，或取消后稍后重试。</p>
+            ) : (
+              <p>请关闭相关进程后重试。</p>
+            )}
+          </>
+        }
+        loading={lockCheckModalLoading}
+        onConfirm={
+          lockCheckModal?.mode === 'checkFailed'
+            ? () => void handleContinueAfterLockCheckFailure()
+            : () => setLockCheckModal(null)
+        }
+        onCancel={() => setLockCheckModal(null)}
       />
     </>
   );

--- a/src/pages/Backup.tsx
+++ b/src/pages/Backup.tsx
@@ -8,8 +8,30 @@ import { useAppStore } from '../stores';
 import { SKIP_OPERATION, findLatestOrSkip, useOperationRunner } from '../hooks';
 import { ConfirmModal, PageHeader } from '../components';
 import { OPERATION_KEYS } from '../constants';
+import { handleApiError, parseProcessLockingError } from '../utils';
 
 const { Text } = Typography;
+
+type LockCheckModalState =
+  | {
+      mode: 'checkFailed';
+      action: 'create';
+      instanceId: string;
+      detail: string;
+      lockingProcesses: string[];
+    }
+  | {
+      mode: 'checkFailed';
+      action: 'restore';
+      backupPath: string;
+      detail: string;
+      lockingProcesses: string[];
+    }
+  | {
+      mode: 'locked';
+      detail: string;
+      lockingProcesses: string[];
+    };
 
 export default function Backup() {
   const instances = useAppStore((s) => s.instances);
@@ -24,9 +46,10 @@ export default function Backup() {
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [selectedBackup, setSelectedBackup] = useState<BackupInfo | null>(null);
   const [backupToDelete, setBackupToDelete] = useState<BackupInfo | null>(null);
+  const [lockCheckModal, setLockCheckModal] = useState<LockCheckModalState | null>(null);
   const [createForm] = Form.useForm();
 
-  const handleCreate = async (values: { instanceId: string }) => {
+  const runCreateBackup = async (instanceId: string, skipLockCheck: boolean = false) => {
     const key = OPERATION_KEYS.backupCreate;
     await runOperation({
       key,
@@ -35,7 +58,7 @@ export default function Backup() {
         const { instances: latestInstances } = useAppStore.getState();
         const latestInstance = findLatestOrSkip(
           latestInstances,
-          (i) => i.id === values.instanceId,
+          (i) => i.id === instanceId,
           '实例不存在或已被删除'
         );
         if (latestInstance === SKIP_OPERATION) {
@@ -46,19 +69,50 @@ export default function Backup() {
           return SKIP_OPERATION;
         }
 
-        await api.createBackup(values.instanceId);
+        if (!skipLockCheck) {
+          await api.checkLock({ target: 'backup_create', instanceId });
+        }
+        await api.createBackup(instanceId);
       },
       onSuccess: () => {
         message.success('备份创建成功');
         setCreateOpen(false);
+        setLockCheckModal(null);
         createForm.resetFields();
+      },
+      onError: (error) => {
+        const lockCheckError = parseProcessLockingError(error);
+        if (!lockCheckError) {
+          handleApiError(error);
+          return;
+        }
+
+        setCreateOpen(false);
+        if (lockCheckError.canContinue) {
+          setLockCheckModal({
+            mode: 'checkFailed',
+            action: 'create',
+            instanceId,
+            detail: lockCheckError.detail,
+            lockingProcesses: lockCheckError.lockingProcesses,
+          });
+          return;
+        }
+
+        setLockCheckModal({
+          mode: 'locked',
+          detail: lockCheckError.detail,
+          lockingProcesses: lockCheckError.lockingProcesses,
+        });
       },
     });
   };
 
-  const handleRestore = async () => {
-    if (!selectedBackup) return;
+  const handleCreate = async (values: { instanceId: string }) => {
+    await runCreateBackup(values.instanceId);
+  };
 
+  const runRestoreBackup = async (backupPath: string, skipLockCheck: boolean = false) => {
     const key = OPERATION_KEYS.backupRestore;
     await runOperation({
       key,
@@ -67,7 +121,7 @@ export default function Backup() {
         const { backups: latestBackups, instances: latestInstances } = useAppStore.getState();
         const latestBackup = findLatestOrSkip(
           latestBackups,
-          (b) => b.path === selectedBackup.path,
+          (b) => b.path === backupPath,
           '备份不存在或已被删除'
         );
         if (latestBackup === SKIP_OPERATION) {
@@ -91,14 +145,49 @@ export default function Backup() {
           return SKIP_OPERATION;
         }
 
+        if (!skipLockCheck) {
+          await api.checkLock({ target: 'backup_restore', backupPath: latestBackup.path });
+        }
         await api.restoreBackup(latestBackup.path);
       },
       onSuccess: () => {
         message.success('备份恢复成功');
         setRestoreOpen(false);
         setSelectedBackup(null);
+        setLockCheckModal(null);
+      },
+      onError: (error) => {
+        const lockCheckError = parseProcessLockingError(error);
+        if (!lockCheckError) {
+          handleApiError(error);
+          return;
+        }
+
+        setRestoreOpen(false);
+        setSelectedBackup(null);
+        if (lockCheckError.canContinue) {
+          setLockCheckModal({
+            mode: 'checkFailed',
+            action: 'restore',
+            backupPath,
+            detail: lockCheckError.detail,
+            lockingProcesses: lockCheckError.lockingProcesses,
+          });
+          return;
+        }
+
+        setLockCheckModal({
+          mode: 'locked',
+          detail: lockCheckError.detail,
+          lockingProcesses: lockCheckError.lockingProcesses,
+        });
       },
     });
+  };
+
+  const handleRestore = async () => {
+    if (!selectedBackup) return;
+    await runRestoreBackup(selectedBackup.path);
   };
 
   const handleDelete = async () => {
@@ -141,8 +230,27 @@ export default function Backup() {
     setDeleteOpen(true);
   };
 
+  const handleContinueAfterLockCheckFailure = async () => {
+    if (!lockCheckModal || lockCheckModal.mode !== 'checkFailed') return;
+
+    if (lockCheckModal.action === 'create') {
+      await runCreateBackup(lockCheckModal.instanceId, true);
+      return;
+    }
+
+    await runRestoreBackup(lockCheckModal.backupPath, true);
+  };
+
   const stoppedInstances = instances.filter((i) => i.state === 'stopped');
   const isAutoGeneratedBackup = (backup: BackupInfo) => !!backup.metadata.auto_generated;
+  const lockCheckModalLoading =
+    lockCheckModal?.mode === 'checkFailed'
+      ? operations[
+          lockCheckModal.action === 'create'
+            ? OPERATION_KEYS.backupCreate
+            : OPERATION_KEYS.backupRestore
+        ] || false
+      : false;
 
   // 所有实例的选项，运行中的实例标记为禁用
   const instanceOptions = instances.map((i) => ({
@@ -308,6 +416,40 @@ export default function Backup() {
           setDeleteOpen(false);
           setBackupToDelete(null);
         }}
+      />
+
+      <ConfirmModal
+        open={lockCheckModal !== null}
+        title={lockCheckModal?.mode === 'locked' ? '目标路径被占用' : '目标路径占用检测失败'}
+        danger={lockCheckModal?.mode === 'locked'}
+        okText={lockCheckModal?.mode === 'checkFailed' ? '继续操作' : '我知道了'}
+        loading={lockCheckModalLoading}
+        content={
+          <>
+            <p>{lockCheckModal?.detail}</p>
+            {lockCheckModal?.lockingProcesses?.length ? (
+              <div>
+                <p>检测到以下进程正在占用目标路径:</p>
+                {lockCheckModal.lockingProcesses.map((process, index) => (
+                  <p key={`${process}-${index}`}>
+                    {index + 1}. {process}
+                  </p>
+                ))}
+              </div>
+            ) : null}
+            {lockCheckModal?.mode === 'checkFailed' ? (
+              <p>可选择继续执行本次操作，或取消后稍后重试。</p>
+            ) : (
+              <p>请关闭相关进程后重试。</p>
+            )}
+          </>
+        }
+        onConfirm={
+          lockCheckModal?.mode === 'checkFailed'
+            ? () => void handleContinueAfterLockCheckFailure()
+            : () => setLockCheckModal(null)
+        }
+        onCancel={() => setLockCheckModal(null)}
       />
     </>
   );

--- a/src/pages/Backup.tsx
+++ b/src/pages/Backup.tsx
@@ -5,32 +5,21 @@ import { api } from '../api';
 import type { BackupInfo } from '../types';
 import { message } from '../antdStatic';
 import { useAppStore } from '../stores';
-import { SKIP_OPERATION, findLatestOrSkip, useOperationRunner } from '../hooks';
-import { ConfirmModal, PageHeader } from '../components';
+import { SKIP_OPERATION, findLatestOrSkip, useOperationRunner, useLockCheckModal } from '../hooks';
+import { ConfirmModal, LockCheckConfirmModal, PageHeader } from '../components';
 import { OPERATION_KEYS } from '../constants';
-import { handleApiError, parseProcessLockingError } from '../utils';
+import { handleApiError } from '../utils';
 
 const { Text } = Typography;
 
-type LockCheckModalState =
+type BackupLockCheckPayload =
   | {
-      mode: 'checkFailed';
       action: 'create';
       instanceId: string;
-      detail: string;
-      lockingProcesses: string[];
     }
   | {
-      mode: 'checkFailed';
       action: 'restore';
       backupPath: string;
-      detail: string;
-      lockingProcesses: string[];
-    }
-  | {
-      mode: 'locked';
-      detail: string;
-      lockingProcesses: string[];
     };
 
 export default function Backup() {
@@ -46,7 +35,8 @@ export default function Backup() {
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [selectedBackup, setSelectedBackup] = useState<BackupInfo | null>(null);
   const [backupToDelete, setBackupToDelete] = useState<BackupInfo | null>(null);
-  const [lockCheckModal, setLockCheckModal] = useState<LockCheckModalState | null>(null);
+  const { lockCheckModal, closeLockCheckModal, handleLockCheckError } =
+    useLockCheckModal<BackupLockCheckPayload>();
   const [createForm] = Form.useForm();
 
   const runCreateBackup = async (instanceId: string, skipLockCheck: boolean = false) => {
@@ -77,33 +67,22 @@ export default function Backup() {
       onSuccess: () => {
         message.success('备份创建成功');
         setCreateOpen(false);
-        setLockCheckModal(null);
+        closeLockCheckModal();
         createForm.resetFields();
       },
       onError: (error) => {
-        const lockCheckError = parseProcessLockingError(error);
-        if (!lockCheckError) {
-          handleApiError(error);
-          return;
-        }
-
-        setCreateOpen(false);
-        if (lockCheckError.canContinue) {
-          setLockCheckModal({
-            mode: 'checkFailed',
+        const handled = handleLockCheckError(error, {
+          checkFailedPayload: {
             action: 'create',
             instanceId,
-            detail: lockCheckError.detail,
-            lockingProcesses: lockCheckError.lockingProcesses,
-          });
-          return;
-        }
-
-        setLockCheckModal({
-          mode: 'locked',
-          detail: lockCheckError.detail,
-          lockingProcesses: lockCheckError.lockingProcesses,
+          },
+          onLockCheckError: () => {
+            setCreateOpen(false);
+          },
         });
+        if (!handled) {
+          handleApiError(error);
+        }
       },
     });
   };
@@ -154,33 +133,22 @@ export default function Backup() {
         message.success('备份恢复成功');
         setRestoreOpen(false);
         setSelectedBackup(null);
-        setLockCheckModal(null);
+        closeLockCheckModal();
       },
       onError: (error) => {
-        const lockCheckError = parseProcessLockingError(error);
-        if (!lockCheckError) {
-          handleApiError(error);
-          return;
-        }
-
-        setRestoreOpen(false);
-        setSelectedBackup(null);
-        if (lockCheckError.canContinue) {
-          setLockCheckModal({
-            mode: 'checkFailed',
+        const handled = handleLockCheckError(error, {
+          checkFailedPayload: {
             action: 'restore',
             backupPath,
-            detail: lockCheckError.detail,
-            lockingProcesses: lockCheckError.lockingProcesses,
-          });
-          return;
-        }
-
-        setLockCheckModal({
-          mode: 'locked',
-          detail: lockCheckError.detail,
-          lockingProcesses: lockCheckError.lockingProcesses,
+          },
+          onLockCheckError: () => {
+            setRestoreOpen(false);
+            setSelectedBackup(null);
+          },
         });
+        if (!handled) {
+          handleApiError(error);
+        }
       },
     });
   };
@@ -230,15 +198,13 @@ export default function Backup() {
     setDeleteOpen(true);
   };
 
-  const handleContinueAfterLockCheckFailure = async () => {
-    if (!lockCheckModal || lockCheckModal.mode !== 'checkFailed') return;
-
-    if (lockCheckModal.action === 'create') {
-      await runCreateBackup(lockCheckModal.instanceId, true);
+  const handleContinueAfterLockCheckFailure = async (payload: BackupLockCheckPayload) => {
+    if (payload.action === 'create') {
+      await runCreateBackup(payload.instanceId, true);
       return;
     }
 
-    await runRestoreBackup(lockCheckModal.backupPath, true);
+    await runRestoreBackup(payload.backupPath, true);
   };
 
   const stoppedInstances = instances.filter((i) => i.state === 'stopped');
@@ -246,7 +212,7 @@ export default function Backup() {
   const lockCheckModalLoading =
     lockCheckModal?.mode === 'checkFailed'
       ? operations[
-          lockCheckModal.action === 'create'
+          lockCheckModal.payload.action === 'create'
             ? OPERATION_KEYS.backupCreate
             : OPERATION_KEYS.backupRestore
         ] || false
@@ -418,38 +384,11 @@ export default function Backup() {
         }}
       />
 
-      <ConfirmModal
-        open={lockCheckModal !== null}
-        title={lockCheckModal?.mode === 'locked' ? '目标路径被占用' : '目标路径占用检测失败'}
-        danger={lockCheckModal?.mode === 'locked'}
-        okText={lockCheckModal?.mode === 'checkFailed' ? '继续操作' : '我知道了'}
+      <LockCheckConfirmModal
+        state={lockCheckModal}
         loading={lockCheckModalLoading}
-        content={
-          <>
-            <p>{lockCheckModal?.detail}</p>
-            {lockCheckModal?.lockingProcesses?.length ? (
-              <div>
-                <p>检测到以下进程正在占用目标路径:</p>
-                {lockCheckModal.lockingProcesses.map((process, index) => (
-                  <p key={`${process}-${index}`}>
-                    {index + 1}. {process}
-                  </p>
-                ))}
-              </div>
-            ) : null}
-            {lockCheckModal?.mode === 'checkFailed' ? (
-              <p>可选择继续执行本次操作，或取消后稍后重试。</p>
-            ) : (
-              <p>请关闭相关进程后重试。</p>
-            )}
-          </>
-        }
-        onConfirm={
-          lockCheckModal?.mode === 'checkFailed'
-            ? () => void handleContinueAfterLockCheckFailure()
-            : () => setLockCheckModal(null)
-        }
-        onCancel={() => setLockCheckModal(null)}
+        onContinue={handleContinueAfterLockCheckFailure}
+        onClose={closeLockCheckModal}
       />
     </>
   );

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -5,10 +5,16 @@ import { PlusOutlined } from '@ant-design/icons';
 import { api } from '../api';
 import { message } from '../antdStatic';
 import type { InstanceStatus, GitHubRelease } from '../types';
-import { SKIP_OPERATION, findLatestOrSkip, useOperationRunner } from '../hooks';
+import { SKIP_OPERATION, findLatestOrSkip, useLockCheckModal, useOperationRunner } from '../hooks';
 import { useAppStore } from '../stores';
-import { DeployProgressModal, ConfirmModal, EditInstanceModal, PageHeader } from '../components';
-import { handleApiError, parseProcessLockingError } from '../utils';
+import {
+  DeployProgressModal,
+  ConfirmModal,
+  EditInstanceModal,
+  LockCheckConfirmModal,
+  PageHeader,
+} from '../components';
+import { handleApiError } from '../utils';
 import { STATUS_MESSAGES, OPERATION_KEYS } from '../constants';
 import { buildDashboardColumns } from './dashboardColumns';
 
@@ -27,19 +33,6 @@ type PendingUpgradeEdit = {
   version: string;
   port: number;
 };
-
-type UpgradeLockModalState =
-  | {
-      mode: 'checkFailed';
-      pending: PendingUpgradeEdit;
-      detail: string;
-      lockingProcesses: string[];
-    }
-  | {
-      mode: 'locked';
-      detail: string;
-      lockingProcesses: string[];
-    };
 
 export default function Dashboard() {
   const navigate = useNavigate();
@@ -69,7 +62,11 @@ export default function Dashboard() {
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [editingInstance, setEditingInstance] = useState<InstanceStatus | null>(null);
   const [instanceToDelete, setInstanceToDelete] = useState<InstanceStatus | null>(null);
-  const [upgradeLockModal, setUpgradeLockModal] = useState<UpgradeLockModalState | null>(null);
+  const {
+    lockCheckModal: upgradeLockModal,
+    closeLockCheckModal: closeUpgradeLockModal,
+    handleLockCheckError: handleUpgradeLockCheckError,
+  } = useLockCheckModal<PendingUpgradeEdit>();
 
   // Forms
   const [createForm] = Form.useForm();
@@ -201,29 +198,21 @@ export default function Dashboard() {
           );
         },
         onSuccess: () => {
-          setUpgradeLockModal(null);
+          closeUpgradeLockModal();
           message.success(STATUS_MESSAGES.INSTANCE_UPDATED);
           // done event from backend auto-closes the modal via event listener
         },
         onError: (error) => {
-          const lockCheckError = parseProcessLockingError(error);
-          if (lockCheckError && !deployStarted) {
-            setEditOpen(false);
-            setEditingInstance(null);
-            if (lockCheckError.canContinue) {
-              setUpgradeLockModal({
-                mode: 'checkFailed',
-                pending: payload,
-                detail: lockCheckError.detail,
-                lockingProcesses: lockCheckError.lockingProcesses,
-              });
-            } else {
-              setUpgradeLockModal({
-                mode: 'locked',
-                detail: lockCheckError.detail,
-                lockingProcesses: lockCheckError.lockingProcesses,
-              });
-            }
+          if (
+            !deployStarted &&
+            handleUpgradeLockCheckError(error, {
+              checkFailedPayload: payload,
+              onLockCheckError: () => {
+                setEditOpen(false);
+                setEditingInstance(null);
+              },
+            })
+          ) {
             return;
           }
 
@@ -234,7 +223,7 @@ export default function Dashboard() {
         },
       });
     },
-    [startDeploy, closeDeploy, runOperation]
+    [startDeploy, closeDeploy, runOperation, closeUpgradeLockModal, handleUpgradeLockCheckError]
   );
 
   const handleEdit = useCallback(
@@ -251,12 +240,12 @@ export default function Dashboard() {
     [editingInstance, runInstanceEdit]
   );
 
-  const handleContinueUpgradeAfterLockCheckFailure = useCallback(async () => {
-    if (!upgradeLockModal || upgradeLockModal.mode !== 'checkFailed') {
-      return;
-    }
-    await runInstanceEdit(upgradeLockModal.pending, { skipLockCheck: true });
-  }, [upgradeLockModal, runInstanceEdit]);
+  const handleContinueUpgradeAfterLockCheckFailure = useCallback(
+    async (pending: PendingUpgradeEdit) => {
+      await runInstanceEdit(pending, { skipLockCheck: true });
+    },
+    [runInstanceEdit]
+  );
 
   const executeInstanceAction = useCallback(
     async <T,>({
@@ -451,7 +440,7 @@ export default function Dashboard() {
   }));
   const upgradeLockModalLoading =
     upgradeLockModal?.mode === 'checkFailed'
-      ? operations[OPERATION_KEYS.instance(upgradeLockModal.pending.instanceId)] || false
+      ? operations[OPERATION_KEYS.instance(upgradeLockModal.payload.instanceId)] || false
       : false;
 
   // ========================================
@@ -556,38 +545,11 @@ export default function Dashboard() {
         }}
       />
 
-      <ConfirmModal
-        open={upgradeLockModal !== null}
-        title={upgradeLockModal?.mode === 'locked' ? '目标路径被占用' : '目标路径占用检测失败'}
-        danger={upgradeLockModal?.mode === 'locked'}
-        okText={upgradeLockModal?.mode === 'checkFailed' ? '继续操作' : '我知道了'}
+      <LockCheckConfirmModal
+        state={upgradeLockModal}
         loading={upgradeLockModalLoading}
-        content={
-          <>
-            <p>{upgradeLockModal?.detail}</p>
-            {upgradeLockModal?.lockingProcesses?.length ? (
-              <div>
-                <p>检测到以下进程正在占用目标路径:</p>
-                {upgradeLockModal.lockingProcesses.map((process, index) => (
-                  <p key={`${process}-${index}`}>
-                    {index + 1}. {process}
-                  </p>
-                ))}
-              </div>
-            ) : null}
-            {upgradeLockModal?.mode === 'checkFailed' ? (
-              <p>可选择继续执行本次操作，或取消后稍后重试。</p>
-            ) : (
-              <p>请关闭相关进程后重试。</p>
-            )}
-          </>
-        }
-        onConfirm={
-          upgradeLockModal?.mode === 'checkFailed'
-            ? () => void handleContinueUpgradeAfterLockCheckFailure()
-            : () => setUpgradeLockModal(null)
-        }
-        onCancel={() => setUpgradeLockModal(null)}
+        onContinue={handleContinueUpgradeAfterLockCheckFailure}
+        onClose={closeUpgradeLockModal}
       />
 
       {/* Deploy Progress Modal */}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -8,7 +8,7 @@ import type { InstanceStatus, GitHubRelease } from '../types';
 import { SKIP_OPERATION, findLatestOrSkip, useOperationRunner } from '../hooks';
 import { useAppStore } from '../stores';
 import { DeployProgressModal, ConfirmModal, EditInstanceModal, PageHeader } from '../components';
-import { handleApiError } from '../utils';
+import { handleApiError, parseProcessLockingError } from '../utils';
 import { STATUS_MESSAGES, OPERATION_KEYS } from '../constants';
 import { buildDashboardColumns } from './dashboardColumns';
 
@@ -20,6 +20,26 @@ type InstanceActionOptions<T> = {
   onSkipped?: () => void;
   onError?: () => void;
 };
+
+type PendingUpgradeEdit = {
+  instanceId: string;
+  name: string;
+  version: string;
+  port: number;
+};
+
+type UpgradeLockModalState =
+  | {
+      mode: 'checkFailed';
+      pending: PendingUpgradeEdit;
+      detail: string;
+      lockingProcesses: string[];
+    }
+  | {
+      mode: 'locked';
+      detail: string;
+      lockingProcesses: string[];
+    };
 
 export default function Dashboard() {
   const navigate = useNavigate();
@@ -49,6 +69,7 @@ export default function Dashboard() {
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [editingInstance, setEditingInstance] = useState<InstanceStatus | null>(null);
   const [instanceToDelete, setInstanceToDelete] = useState<InstanceStatus | null>(null);
+  const [upgradeLockModal, setUpgradeLockModal] = useState<UpgradeLockModalState | null>(null);
 
   // Forms
   const [createForm] = Form.useForm();
@@ -129,19 +150,19 @@ export default function Dashboard() {
     [createForm, runOperation]
   );
 
-  const handleEdit = useCallback(
-    async (values: { name: string; version: string; port?: number }) => {
-      if (!editingInstance) return;
-
+  const runInstanceEdit = useCallback(
+    async (payload: PendingUpgradeEdit, options?: { skipLockCheck?: boolean }) => {
+      const skipLockCheck = options?.skipLockCheck ?? false;
       let deployStarted = false;
+
       await runOperation({
-        key: OPERATION_KEYS.instance(editingInstance.id),
+        key: OPERATION_KEYS.instance(payload.instanceId),
         reloadBefore: true,
         task: async () => {
           const { instances: latestInstances, versions: latestVersions } = useAppStore.getState();
           const latestInstance = findLatestOrSkip(
             latestInstances,
-            (i) => i.id === editingInstance.id,
+            (i) => i.id === payload.instanceId,
             '实例不存在或已被删除'
           );
           if (latestInstance === SKIP_OPERATION) {
@@ -150,13 +171,21 @@ export default function Dashboard() {
             return SKIP_OPERATION;
           }
 
-          if (!latestVersions.some((v) => v.version === values.version)) {
+          if (!latestVersions.some((v) => v.version === payload.version)) {
             message.warning('所选版本不存在，请先刷新后重试');
             return SKIP_OPERATION;
           }
 
-          if (values.version !== latestInstance.version) {
-            const cmp = await api.compareVersions(values.version, latestInstance.version);
+          const versionChanged = payload.version !== latestInstance.version;
+          if (versionChanged && !skipLockCheck) {
+            await api.checkLock({
+              target: 'instance_upgrade',
+              instanceId: latestInstance.id,
+            });
+          }
+
+          if (versionChanged) {
+            const cmp = await api.compareVersions(payload.version, latestInstance.version);
             const deployType = cmp > 0 ? 'upgrade' : 'downgrade';
             startDeploy(latestInstance.name, deployType);
             deployStarted = true;
@@ -166,16 +195,38 @@ export default function Dashboard() {
           setEditingInstance(null);
           await api.updateInstance(
             latestInstance.id,
-            values.name,
-            values.version,
-            values.port ?? 0
+            payload.name,
+            payload.version,
+            payload.port
           );
         },
         onSuccess: () => {
+          setUpgradeLockModal(null);
           message.success(STATUS_MESSAGES.INSTANCE_UPDATED);
           // done event from backend auto-closes the modal via event listener
         },
         onError: (error) => {
+          const lockCheckError = parseProcessLockingError(error);
+          if (lockCheckError && !deployStarted) {
+            setEditOpen(false);
+            setEditingInstance(null);
+            if (lockCheckError.canContinue) {
+              setUpgradeLockModal({
+                mode: 'checkFailed',
+                pending: payload,
+                detail: lockCheckError.detail,
+                lockingProcesses: lockCheckError.lockingProcesses,
+              });
+            } else {
+              setUpgradeLockModal({
+                mode: 'locked',
+                detail: lockCheckError.detail,
+                lockingProcesses: lockCheckError.lockingProcesses,
+              });
+            }
+            return;
+          }
+
           handleApiError(error);
           if (deployStarted) {
             closeDeploy();
@@ -183,8 +234,29 @@ export default function Dashboard() {
         },
       });
     },
-    [editingInstance, startDeploy, closeDeploy, runOperation]
+    [startDeploy, closeDeploy, runOperation]
   );
+
+  const handleEdit = useCallback(
+    async (values: { name: string; version: string; port?: number }) => {
+      if (!editingInstance) return;
+
+      await runInstanceEdit({
+        instanceId: editingInstance.id,
+        name: values.name,
+        version: values.version,
+        port: values.port ?? 0,
+      });
+    },
+    [editingInstance, runInstanceEdit]
+  );
+
+  const handleContinueUpgradeAfterLockCheckFailure = useCallback(async () => {
+    if (!upgradeLockModal || upgradeLockModal.mode !== 'checkFailed') {
+      return;
+    }
+    await runInstanceEdit(upgradeLockModal.pending, { skipLockCheck: true });
+  }, [upgradeLockModal, runInstanceEdit]);
 
   const executeInstanceAction = useCallback(
     async <T,>({
@@ -377,6 +449,10 @@ export default function Dashboard() {
     label: v.version,
     value: v.version,
   }));
+  const upgradeLockModalLoading =
+    upgradeLockModal?.mode === 'checkFailed'
+      ? operations[OPERATION_KEYS.instance(upgradeLockModal.pending.instanceId)] || false
+      : false;
 
   // ========================================
   // Render
@@ -478,6 +554,40 @@ export default function Dashboard() {
           setDeleteOpen(false);
           setInstanceToDelete(null);
         }}
+      />
+
+      <ConfirmModal
+        open={upgradeLockModal !== null}
+        title={upgradeLockModal?.mode === 'locked' ? '目标路径被占用' : '目标路径占用检测失败'}
+        danger={upgradeLockModal?.mode === 'locked'}
+        okText={upgradeLockModal?.mode === 'checkFailed' ? '继续操作' : '我知道了'}
+        loading={upgradeLockModalLoading}
+        content={
+          <>
+            <p>{upgradeLockModal?.detail}</p>
+            {upgradeLockModal?.lockingProcesses?.length ? (
+              <div>
+                <p>检测到以下进程正在占用目标路径:</p>
+                {upgradeLockModal.lockingProcesses.map((process, index) => (
+                  <p key={`${process}-${index}`}>
+                    {index + 1}. {process}
+                  </p>
+                ))}
+              </div>
+            ) : null}
+            {upgradeLockModal?.mode === 'checkFailed' ? (
+              <p>可选择继续执行本次操作，或取消后稍后重试。</p>
+            ) : (
+              <p>请关闭相关进程后重试。</p>
+            )}
+          </>
+        }
+        onConfirm={
+          upgradeLockModal?.mode === 'checkFailed'
+            ? () => void handleContinueUpgradeAfterLockCheckFailure()
+            : () => setUpgradeLockModal(null)
+        }
+        onCancel={() => setUpgradeLockModal(null)}
       />
 
       {/* Deploy Progress Modal */}

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,8 +1,17 @@
 import { message } from '../antdStatic';
-import { getErrorText } from '../constants/errorCodes';
+import { ErrorCode, getErrorText } from '../constants/errorCodes';
 import type { AppError } from '../types';
 
-function isAppError(error: unknown): error is AppError {
+export type LockCheckFailureReason = 'check_failed' | 'locked';
+
+export interface ProcessLockingErrorInfo {
+  reason: LockCheckFailureReason;
+  detail: string;
+  canContinue: boolean;
+  lockingProcesses: string[];
+}
+
+export function isAppError(error: unknown): error is AppError {
   return (
     typeof error === 'object' &&
     error !== null &&
@@ -23,6 +32,36 @@ export function getErrorMessage(error: unknown): string {
   if (error instanceof Error) return error.message;
   if (typeof error === 'string') return error;
   return String(error);
+}
+
+function parseLockingProcesses(rawValue: string | undefined): string[] {
+  if (!rawValue) return [];
+  try {
+    const parsed = JSON.parse(rawValue);
+    if (Array.isArray(parsed)) {
+      return parsed.filter((item): item is string => typeof item === 'string');
+    }
+    return [];
+  } catch {
+    return [];
+  }
+}
+
+export function parseProcessLockingError(error: unknown): ProcessLockingErrorInfo | null {
+  if (!isAppError(error) || error.code !== ErrorCode.PROCESS_LOCKING) {
+    return null;
+  }
+
+  const reason: LockCheckFailureReason =
+    error.payload.reason === 'locked' ? 'locked' : 'check_failed';
+  const detail = getErrorText(error.code, error.payload);
+
+  return {
+    reason,
+    detail,
+    canContinue: reason === 'check_failed' && error.payload.can_continue === 'true',
+    lockingProcesses: parseLockingProcesses(error.payload.locking_processes),
+  };
 }
 
 /**

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,2 +1,7 @@
-export { getErrorMessage, handleApiError } from './error';
+export {
+  getErrorMessage,
+  handleApiError,
+  isAppError,
+  parseProcessLockingError,
+} from './error';
 export { isInstanceDeploying } from './deploy';


### PR DESCRIPTION
Introduce a lock check mechanism for backup and instance operations, allowing the application to verify if the target resources are locked before proceeding. This includes enhancements to error handling and the addition of relevant API calls to manage locking states effectively.

## Summary by Sourcery

Add a reusable lock-check flow for backup, instance upgrade, and advanced cleanup operations, surfacing lock status via dedicated confirmation modals and a new backend check API.

New Features:
- Introduce frontend lock-check confirmation modals for backups, instance upgrades, and advanced clear operations, allowing users to see locking processes and optionally continue when checks fail.
- Add a generic lock-check Tauri command and corresponding API wrapper that validates targets and ensures related data paths are not locked before operations proceed.

Enhancements:
- Refine process-locking error handling with structured payloads, parsable locking process lists, and client-side helpers to distinguish between hard locks and check failures.
- Refactor backup, instance edit, and advanced clear flows to reuse lock-check logic and separate core operation runners from UI handlers.