### PR TITLE
fix: avoid bottom clipping in embedded WebUI layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -76,14 +76,15 @@ function AppLayout() {
   ];
 
   return (
-    <div style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
-      <Layout style={{ flex: 1, overflow: 'hidden' }}>
+    <div style={{ height: '100%', minHeight: 0, display: 'flex', flexDirection: 'column' }}>
+      <Layout style={{ flex: 1, minHeight: 0, overflow: 'hidden' }}>
         <Sider
           width={180}
           theme="light"
           style={{
             overflow: 'auto',
             height: '100%',
+            minHeight: 0,
           }}
         >
           <Menu
@@ -94,8 +95,8 @@ function AppLayout() {
             style={{ borderRight: 0 }}
           />
         </Sider>
-        <Layout>
-          <Content style={{ padding: 24, overflow: 'auto', height: '100%' }}>
+        <Layout style={{ minHeight: 0 }}>
+          <Content style={{ padding: 24, overflow: 'auto', height: '100%', minHeight: 0 }}>
             <ErrorBoundary>
               <Routes>
                 <Route path="/" element={<Dashboard />} />
@@ -158,7 +159,7 @@ function App({ isMacOS }: { isMacOS: boolean }) {
         <AntdStaticProvider />
         <div style={{ height: '100vh', display: 'flex', flexDirection: 'column' }}>
           {!isMacOS && <TitleBar />}
-          <div style={{ flex: 1, height: 0, overflow: 'hidden' }}>
+          <div style={{ flex: 1, height: 0, minHeight: 0, overflow: 'hidden' }}>
             <BrowserRouter>
               <Suspense>
                 <Routes>

--- a/src/pages/Logs.tsx
+++ b/src/pages/Logs.tsx
@@ -86,9 +86,10 @@ export default function Logs() {
             height: '100%',
             display: 'flex',
             flexDirection: 'column',
+            minHeight: 0,
           },
         }}
-        style={{ flex: 1, display: 'flex', flexDirection: 'column' }}
+        style={{ flex: 1, display: 'flex', flexDirection: 'column', minHeight: 0 }}
       >
         {logs.length === 0 ? (
           <Flex flex={1} align="center" justify="center">
@@ -105,7 +106,6 @@ export default function Logs() {
               background: '#1a1a2e',
               color: '#d4d4d4',
               borderRadius: 'inherit',
-              maxHeight: 'calc(100vh - 170px)',
               fontFamily:
                 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
               fontSize: 12,

--- a/src/pages/WebUIView.tsx
+++ b/src/pages/WebUIView.tsx
@@ -32,7 +32,7 @@ export default function WebUIView() {
           display: 'flex',
           justifyContent: 'center',
           alignItems: 'center',
-          height: '100vh',
+          height: '100%',
         }}
       >
         <Spin size="large" />
@@ -52,7 +52,7 @@ export default function WebUIView() {
   }
 
   return (
-    <div style={{ height: '100vh', display: 'flex', flexDirection: 'column' }}>
+    <div style={{ height: '100%', display: 'flex', flexDirection: 'column', minHeight: 0 }}>
       <div
         style={{
           height: 40,
@@ -74,6 +74,7 @@ export default function WebUIView() {
         src={`http://localhost:${port}`}
         style={{
           flex: 1,
+          minHeight: 0,
           border: 'none',
           width: '100%',
         }}


### PR DESCRIPTION
## Summary by Sourcery

Adjust layout sizing to prevent bottom content from being clipped in the embedded WebUI and related views.

Bug Fixes:
- Ensure main app layout and content areas respect container height without clipping by adding minHeight constraints.
- Fix embedded WebUI and loading spinner views to use container-relative height instead of full viewport height to avoid cutoff in embedded contexts.
- Prevent logs page content from being clipped by enforcing flex container minHeight instead of relying on viewport-based maxHeight.