### PR TITLE
Add instance manifest rebuild functionality

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -447,6 +447,19 @@ pub async fn clear_pycache(instance_id: String, state: State<'_, AppState>) -> R
     instance::clear_pycache(&instance_id)
 }
 
+#[tauri::command]
+pub async fn rebuild_instance_manifest(
+    state: State<'_, AppState>,
+) -> Result<instance::RebuildInstanceManifestResult> {
+    if !state.process_manager.get_active_ids().is_empty() {
+        return Err(AppError::instance_running());
+    }
+
+    tokio::task::spawn_blocking(instance::rebuild_instance_manifest_from_disk)
+        .await
+        .map_err(|e| AppError::process(format!("Rebuild instance manifest task panicked: {}", e)))?
+}
+
 // === Instance Management ===
 
 #[tauri::command]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -455,9 +455,12 @@ pub async fn rebuild_instance_manifest(
         return Err(AppError::instance_running());
     }
 
-    tokio::task::spawn_blocking(instance::rebuild_instance_manifest_from_disk)
+    let result = tokio::task::spawn_blocking(instance::rebuild_instance_manifest_from_disk)
         .await
-        .map_err(|e| AppError::process(format!("Rebuild instance manifest task panicked: {}", e)))?
+        .map_err(|e| {
+            AppError::process(format!("Rebuild instance manifest task panicked: {}", e))
+        })??;
+    Ok(result)
 }
 
 // === Instance Management ===

--- a/src-tauri/src/instance/mod.rs
+++ b/src-tauri/src/instance/mod.rs
@@ -10,6 +10,7 @@ mod cleanup;
 mod crud;
 mod deploy;
 pub(crate) mod lifecycle;
+mod rebuild;
 mod types;
 
 // Re-export types
@@ -17,6 +18,9 @@ pub use types::InstanceStatus;
 
 // Re-export CRUD operations
 pub use crud::{create_instance, delete_instance, list_instances, update_instance};
+
+// Re-export rebuild operations
+pub use rebuild::{rebuild_instance_manifest_from_disk, RebuildInstanceManifestResult};
 
 // Re-export cleanup
 pub use cleanup::{clear_instance_data, clear_instance_venv, clear_pycache};

--- a/src-tauri/src/instance/rebuild.rs
+++ b/src-tauri/src/instance/rebuild.rs
@@ -1,6 +1,6 @@
 //! Rebuild instance and version manifest entries by scanning the data directory.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::Path;
 
@@ -24,7 +24,7 @@ pub fn rebuild_instance_manifest_from_disk() -> Result<RebuildInstanceManifestRe
     with_manifest_mut(move |manifest| {
         manifest.installed_versions = installed_versions;
         manifest.instances = instances;
-        let rebuilt_ids: Vec<String> = manifest.instances.keys().cloned().collect();
+        let rebuilt_ids: HashSet<String> = manifest.instances.keys().cloned().collect();
         manifest
             .tracked_instances_snapshot
             .retain(|id| rebuilt_ids.contains(id));

--- a/src-tauri/src/instance/rebuild.rs
+++ b/src-tauri/src/instance/rebuild.rs
@@ -1,0 +1,184 @@
+//! Rebuild instance and version manifest entries by scanning the data directory.
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+use crate::config::{with_manifest_mut, InstalledVersion, InstanceConfig};
+use crate::error::{AppError, Result};
+use crate::utils::paths::{get_data_dir, get_versions_dir};
+use crate::utils::validation::validate_instance_id;
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct RebuildInstanceManifestResult {
+    pub instances: usize,
+    pub versions: usize,
+}
+
+pub fn rebuild_instance_manifest_from_disk() -> Result<RebuildInstanceManifestResult> {
+    let installed_versions = scan_installed_versions()?;
+    let instances = scan_instances()?;
+    let instance_count = instances.len();
+    let version_count = installed_versions.len();
+
+    with_manifest_mut(move |manifest| {
+        manifest.installed_versions = installed_versions;
+        manifest.instances = instances;
+        let rebuilt_ids: Vec<String> = manifest.instances.keys().cloned().collect();
+        manifest
+            .tracked_instances_snapshot
+            .retain(|id| rebuilt_ids.contains(id));
+        Ok(())
+    })?;
+
+    Ok(RebuildInstanceManifestResult {
+        instances: instance_count,
+        versions: version_count,
+    })
+}
+
+fn scan_installed_versions() -> Result<Vec<InstalledVersion>> {
+    let versions_dir = get_versions_dir();
+    if !versions_dir.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut versions = Vec::new();
+    for entry in fs::read_dir(&versions_dir)
+        .map_err(|e| AppError::io(format!("Failed to read versions dir: {}", e)))?
+    {
+        let entry = entry.map_err(|e| AppError::io(e.to_string()))?;
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+
+        let Some(filename) = path.file_name().and_then(|name| name.to_str()) else {
+            log::warn!(
+                "Skipping version archive with non-UTF-8 filename: {:?}",
+                path
+            );
+            continue;
+        };
+        let Some(version) = filename.strip_suffix(".zip") else {
+            continue;
+        };
+        let Some(zip_path) = path.to_str() else {
+            log::warn!("Skipping version archive with non-UTF-8 path: {:?}", path);
+            continue;
+        };
+
+        versions.push(InstalledVersion {
+            version: version.to_string(),
+            zip_path: zip_path.to_string(),
+        });
+    }
+
+    Ok(versions)
+}
+
+fn scan_instances() -> Result<HashMap<String, InstanceConfig>> {
+    let instances_dir = get_data_dir().join("instances");
+    if !instances_dir.exists() {
+        return Ok(HashMap::new());
+    }
+
+    let mut instances = HashMap::new();
+
+    for entry in fs::read_dir(&instances_dir)
+        .map_err(|e| AppError::io(format!("Failed to read instances dir: {}", e)))?
+    {
+        let entry = entry.map_err(|e| AppError::io(e.to_string()))?;
+        if !entry
+            .file_type()
+            .map_err(|e| AppError::io(e.to_string()))?
+            .is_dir()
+        {
+            continue;
+        }
+
+        let Some(instance_id) = entry.file_name().to_str().map(str::to_string) else {
+            log::warn!(
+                "Skipping instance directory with non-UTF-8 name: {:?}",
+                entry.path()
+            );
+            continue;
+        };
+        if let Err(error) = validate_instance_id(&instance_id) {
+            log::warn!(
+                "Skipping invalid instance directory {}: {}",
+                instance_id,
+                error
+            );
+            continue;
+        }
+
+        let instance_dir = entry.path();
+        if !looks_like_instance_dir(&instance_dir) {
+            log::warn!(
+                "Skipping instance directory without recognizable content: {:?}",
+                instance_dir
+            );
+            continue;
+        }
+
+        let Some(version) = read_pyproject_version(&instance_dir) else {
+            log::warn!(
+                "Skipping instance {} because core/pyproject.toml has no project.version",
+                instance_id
+            );
+            continue;
+        };
+
+        let instance = InstanceConfig {
+            name: default_instance_name(&instance_id),
+            version,
+            port: 0,
+            created_at: chrono::Utc::now().to_rfc3339(),
+        };
+
+        instances.insert(instance_id, instance);
+    }
+
+    Ok(instances)
+}
+
+fn looks_like_instance_dir(instance_dir: &Path) -> bool {
+    let core_dir = instance_dir.join("core");
+    instance_dir.join("venv").exists()
+        || core_dir.join("main.py").exists()
+        || core_dir.join("data").exists()
+        || core_dir.join("pyproject.toml").exists()
+        || core_dir.join("requirements.txt").exists()
+}
+
+fn read_pyproject_version(instance_dir: &Path) -> Option<String> {
+    let pyproject_path = instance_dir.join("core").join("pyproject.toml");
+    let content = fs::read_to_string(&pyproject_path).ok()?;
+    let value = match toml::from_str::<toml::Value>(&content) {
+        Ok(value) => value,
+        Err(error) => {
+            log::warn!("Failed to parse {:?}: {}", pyproject_path, error);
+            return None;
+        }
+    };
+    let version = value
+        .get("project")
+        .and_then(|project| project.get("version"))
+        .and_then(toml::Value::as_str)?
+        .trim();
+
+    if version.is_empty() {
+        return None;
+    }
+    if version.starts_with('v') {
+        Some(version.to_string())
+    } else {
+        Some(format!("v{}", version))
+    }
+}
+
+fn default_instance_name(instance_id: &str) -> String {
+    let short_id: String = instance_id.chars().take(8).collect();
+    format!("Rev {}", short_id)
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -137,6 +137,7 @@ pub fn run() {
             commands::clear_instance_data,
             commands::clear_instance_venv,
             commands::clear_pycache,
+            commands::rebuild_instance_manifest,
             // Instance Management
             commands::create_instance,
             commands::delete_instance,

--- a/src/api.ts
+++ b/src/api.ts
@@ -79,6 +79,8 @@ export const api = {
     }),
   clearInstanceVenv: (instanceId: string) => invoke<void>('clear_instance_venv', { instanceId }),
   clearPycache: (instanceId: string) => invoke<void>('clear_pycache', { instanceId }),
+  rebuildInstanceManifest: () =>
+    invoke<{ instances: number; versions: number }>('rebuild_instance_manifest'),
 
   // ========================================
   // Instance Management

--- a/src/components/advanced/TroubleshootingCard.tsx
+++ b/src/components/advanced/TroubleshootingCard.tsx
@@ -1,5 +1,5 @@
 import { Alert, Button, Card, Select, Space, Switch, Typography } from 'antd';
-import { PlayCircleOutlined } from '@ant-design/icons';
+import { PlayCircleOutlined, ReloadOutlined } from '@ant-design/icons';
 
 const { Text } = Typography;
 
@@ -61,16 +61,18 @@ interface TroubleshootingCardProps {
   selectedDataInstance: string | null;
   selectedVenvInstance: string | null;
   selectedPycacheInstance: string | null;
-  confirmModal: 'clearData' | 'clearVenv' | 'clearPycache' | null;
+  confirmModal: 'clearData' | 'clearVenv' | 'clearPycache' | 'rebuildManifest' | null;
   clearDataLoading: boolean;
   clearVenvLoading: boolean;
   clearPycacheLoading: boolean;
+  rebuildManifestLoading: boolean;
   onSelectDataInstance: (id: string | null) => void;
   onSelectVenvInstance: (id: string | null) => void;
   onSelectPycacheInstance: (id: string | null) => void;
   onOpenClearData: () => void;
   onOpenClearVenv: () => void;
   onOpenClearPycache: () => void;
+  onOpenRebuildManifest: () => void;
   onIgnoreExternalPathChange: (checked: boolean) => void;
 }
 
@@ -87,12 +89,14 @@ export function TroubleshootingCard({
   clearDataLoading,
   clearVenvLoading,
   clearPycacheLoading,
+  rebuildManifestLoading,
   onSelectDataInstance,
   onSelectVenvInstance,
   onSelectPycacheInstance,
   onOpenClearData,
   onOpenClearVenv,
   onOpenClearPycache,
+  onOpenRebuildManifest,
   onIgnoreExternalPathChange,
 }: TroubleshootingCardProps) {
   return (
@@ -123,6 +127,19 @@ export function TroubleshootingCard({
 
       <div style={{ marginBottom: 24 }}>
         <Space orientation="vertical" style={{ width: '100%' }}>
+          <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
+            <Text style={{ width: 140 }}>重建实例清单:</Text>
+            <Button
+              danger
+              icon={<ReloadOutlined />}
+              loading={rebuildManifestLoading}
+              disabled={rebuildManifestLoading || runningInstancesCount > 0}
+              onClick={onOpenRebuildManifest}
+            >
+              扫描并重建
+            </Button>
+            <Text type="secondary">扫描当前文件并重建实例与版本状态，适用于数据库异常丢失</Text>
+          </div>
           <ActionRow
             label="清空 data 目录"
             options={stoppedInstanceOptions}

--- a/src/constants/operationKeys.ts
+++ b/src/constants/operationKeys.ts
@@ -29,4 +29,5 @@ export const OPERATION_KEYS = {
   advancedClearData: (instanceId: string) => `adv:data-${instanceId}`,
   advancedClearVenv: (instanceId: string) => `adv:venv-${instanceId}`,
   advancedClearPycache: (instanceId: string) => `adv:pycache-${instanceId}`,
+  advancedRebuildInstanceManifest: 'adv:rebuild-instance-manifest',
 } as const;

--- a/src/pages/Advanced.tsx
+++ b/src/pages/Advanced.tsx
@@ -24,7 +24,7 @@ import {
   validatePypiMirror,
 } from './advancedSettings.validation';
 
-type ConfirmModalType = 'clearData' | 'clearVenv' | 'clearPycache' | null;
+type ConfirmModalType = 'clearData' | 'clearVenv' | 'clearPycache' | 'rebuildManifest' | null;
 type SaveSettingOptions = {
   key: string;
   save: () => Promise<void>;
@@ -50,7 +50,7 @@ type SourceSettingConfig = {
   successMessage: string;
   reloadBefore?: boolean;
 };
-type ClearActionType = Exclude<ConfirmModalType, null>;
+type ClearActionType = 'clearData' | 'clearVenv' | 'clearPycache';
 type LockCheckRetryPayload = {
   retry: () => Promise<void>;
   operationKey: string;
@@ -434,6 +434,29 @@ export default function Advanced() {
     await payload.retry();
   };
 
+  const handleRebuildInstanceManifest = async () => {
+    await runOperation({
+      key: OPERATION_KEYS.advancedRebuildInstanceManifest,
+      reloadBefore: true,
+      reloadAfter: false,
+      task: async () => {
+        const { instances: latestInstances } = useAppStore.getState();
+        if (latestInstances.some((i) => i.state !== 'stopped')) {
+          message.warning('请先停止所有实例再重建实例清单');
+          return SKIP_OPERATION;
+        }
+
+        const result = await api.rebuildInstanceManifest();
+        await reloadSnapshot({ throwOnError: true });
+        return result;
+      },
+      onSuccess: (result) => {
+        message.success(`实例清单已重建：${result.instances} 个实例，${result.versions} 个版本`);
+        setConfirmModal(null);
+      },
+    });
+  };
+
   const instanceOptions = instances.map((i) => ({
     label: i.name,
     value: i.id,
@@ -458,6 +481,8 @@ export default function Advanced() {
     : false;
   const ignoreExternalPathSaving =
     operations[OPERATION_KEYS.advancedSaveIgnoreExternalPath] || false;
+  const rebuildManifestLoading =
+    operations[OPERATION_KEYS.advancedRebuildInstanceManifest] || false;
   const lockCheckExtensionWhitelistSaving =
     operations[OPERATION_KEYS.advancedSaveLockCheckExtensionWhitelist] || false;
   const lockCheckModalLoading =
@@ -473,6 +498,8 @@ export default function Advanced() {
         return clearVenvLoading;
       case 'clearPycache':
         return clearPycacheLoading;
+      case 'rebuildManifest':
+        return rebuildManifestLoading;
       default:
         return false;
     }
@@ -500,6 +527,14 @@ export default function Advanced() {
           content: '确定清空该实例的 Python 缓存？',
           onOk: () => void handleClearByType('clearPycache'),
           isDanger: false,
+        };
+      case 'rebuildManifest':
+        return {
+          title: '警告',
+          content:
+            '确定扫描当前文件并重建实例清单？这会强制使用磁盘上数据生成实例清单。',
+          onOk: () => void handleRebuildInstanceManifest(),
+          isDanger: true,
         };
       default:
         return null;
@@ -589,12 +624,14 @@ export default function Advanced() {
         clearDataLoading={clearDataLoading}
         clearVenvLoading={clearVenvLoading}
         clearPycacheLoading={clearPycacheLoading}
+        rebuildManifestLoading={rebuildManifestLoading}
         onSelectDataInstance={setSelectedDataInstance}
         onSelectVenvInstance={setSelectedVenvInstance}
         onSelectPycacheInstance={setSelectedPycacheInstance}
         onOpenClearData={() => setConfirmModal('clearData')}
         onOpenClearVenv={() => setConfirmModal('clearVenv')}
         onOpenClearPycache={() => setConfirmModal('clearPycache')}
+        onOpenRebuildManifest={() => setConfirmModal('rebuildManifest')}
         onIgnoreExternalPathChange={handleIgnoreExternalPathChange}
       />
 


### PR DESCRIPTION
Introduce a command to rebuild the instance manifest, allowing users to regenerate the instance and version states from disk. This feature includes UI updates for triggering the rebuild and handling loading states.

## Summary by Sourcery

Add the ability to rebuild the instance manifest by scanning disk state and expose it via the advanced troubleshooting UI.

New Features:
- Introduce a backend command to rebuild the instance and version manifest from existing data and version files.
- Add an advanced UI control and confirmation flow to trigger manifest rebuild when no instances are running.

Enhancements:
- Ensure manifest rebuild updates tracked instance snapshots consistently and filters out invalid or unrecognizable instance directories.
- Wire manifest rebuild into the operation tracking system with dedicated loading and warning messaging.