### PR TITLE
Add instance repair functionality

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -448,6 +448,17 @@ pub async fn clear_pycache(instance_id: String, state: State<'_, AppState>) -> R
 }
 
 #[tauri::command]
+pub async fn repair_instance(
+    app_handle: AppHandle,
+    instance_id: String,
+    preserve_scope: instance::RepairPreserveScope,
+    state: State<'_, AppState>,
+) -> Result<()> {
+    let _guard = state.process_manager.acquire_guard(&instance_id)?;
+    instance::repair_instance(&instance_id, preserve_scope, &app_handle).await
+}
+
+#[tauri::command]
 pub async fn rebuild_instance_manifest(
     state: State<'_, AppState>,
 ) -> Result<instance::RebuildInstanceManifestResult> {

--- a/src-tauri/src/instance/cleanup.rs
+++ b/src-tauri/src/instance/cleanup.rs
@@ -51,7 +51,7 @@ pub fn clear_pycache(instance_id: &str) -> Result<()> {
     Ok(())
 }
 
-fn clear_pycache_recursive(dir: &Path) -> Result<()> {
+pub(super) fn clear_pycache_recursive(dir: &Path) -> Result<()> {
     if !dir.exists() {
         return Ok(());
     }

--- a/src-tauri/src/instance/deploy.rs
+++ b/src-tauri/src/instance/deploy.rs
@@ -1,7 +1,7 @@
 //! Instance deployment functionality.
 
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use tauri::{AppHandle, Emitter as _};
 
@@ -12,6 +12,15 @@ use crate::config::{load_config, load_manifest, with_config_mut};
 use crate::error::{AppError, Result};
 use crate::utils::paths::{get_instance_core_dir, get_instance_venv_dir, get_venv_python};
 use crate::utils::validation::validate_instance_id;
+
+#[derive(Debug, Clone, Copy, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RepairPreserveScope {
+    DataDirectory,
+    ConfigAndDataFiles,
+    CoreConfigAndDataFiles,
+    DatabaseOnly,
+}
 
 /// Emit deployment progress event.
 pub fn emit_progress(
@@ -103,6 +112,88 @@ pub async fn deploy_instance_with_version(
     Ok(())
 }
 
+pub async fn repair_instance(
+    instance_id: &str,
+    preserve_scope: RepairPreserveScope,
+    app_handle: &AppHandle,
+) -> Result<()> {
+    validate_instance_id(instance_id)?;
+
+    let manifest = load_manifest()?;
+    let version = manifest
+        .instances
+        .get(instance_id)
+        .ok_or_else(|| AppError::instance_not_found(instance_id))?
+        .version
+        .clone();
+    let installed = manifest
+        .installed_versions
+        .iter()
+        .find(|v| v.version == version)
+        .ok_or_else(|| AppError::version_not_found(&version))?;
+    let zip_path = PathBuf::from(&installed.zip_path);
+    if !zip_path.exists() {
+        return Err(AppError::io(format!(
+            "Version zip file not found: {:?}",
+            zip_path
+        )));
+    }
+
+    emit_progress(app_handle, instance_id, "extract", "正在准备修复实例...", 5);
+
+    let core_dir = get_instance_core_dir(instance_id);
+    let venv_dir = get_instance_venv_dir(instance_id);
+    clear_stale_preserve_dirs(instance_id);
+    let preserved = preserve_selected_data(instance_id, &core_dir, preserve_scope)?;
+
+    if venv_dir.exists() {
+        fs::remove_dir_all(&venv_dir).map_err(|e| {
+            AppError::io(format!(
+                "Failed to remove venv directory {:?}: {}",
+                venv_dir, e
+            ))
+        })?;
+    }
+
+    match preserve_scope {
+        RepairPreserveScope::DataDirectory => {
+            fs::create_dir_all(&core_dir)
+                .map_err(|e| AppError::io(format!("Failed to create core dir: {}", e)))?;
+            clear_core_except_data(&core_dir)?;
+        }
+        _ => {
+            if core_dir.exists() {
+                fs::remove_dir_all(&core_dir).map_err(|e| {
+                    AppError::io(format!(
+                        "Failed to remove core directory {:?}: {}",
+                        core_dir, e
+                    ))
+                })?;
+            }
+        }
+    }
+
+    deploy_instance_with_version(instance_id, &version, app_handle).await?;
+
+    if let Some(preserved) = preserved {
+        emit_progress(
+            app_handle,
+            instance_id,
+            "restore",
+            "正在恢复保留数据...",
+            92,
+        );
+        restore_preserved_data(&core_dir, &preserved)?;
+        remove_preserve_dir(&preserved.temp_dir);
+        emit_progress(app_handle, instance_id, "restore", "保留数据恢复完成", 95);
+    }
+
+    clear_pycache_in_dirs(&core_dir, &venv_dir)?;
+    emit_progress(app_handle, instance_id, "done", "实例修复完成", 100);
+
+    Ok(())
+}
+
 fn clear_core_except_data(core_dir: &Path) -> Result<()> {
     if !core_dir.exists() {
         return Ok(());
@@ -132,6 +223,195 @@ fn clear_core_except_data(core_dir: &Path) -> Result<()> {
             fs::remove_file(&path)
                 .map_err(|e| AppError::io(format!("Failed to clear file {:?}: {}", path, e)))?;
         }
+    }
+
+    Ok(())
+}
+
+struct PreservedData {
+    temp_dir: PathBuf,
+    items: Vec<PreservedItem>,
+}
+
+struct PreservedItem {
+    relative_path: PathBuf,
+    temp_path: PathBuf,
+}
+
+fn preserve_selected_data(
+    instance_id: &str,
+    core_dir: &Path,
+    preserve_scope: RepairPreserveScope,
+) -> Result<Option<PreservedData>> {
+    if matches!(preserve_scope, RepairPreserveScope::DataDirectory) {
+        return Ok(None);
+    }
+
+    let data_dir = core_dir.join("data");
+    if !data_dir.exists() {
+        return Ok(None);
+    }
+
+    let temp_dir = crate::utils::paths::get_instance_dir(instance_id)
+        .join(format!(".repair-preserve-{}", uuid::Uuid::new_v4()));
+    fs::create_dir_all(&temp_dir).map_err(|e| {
+        AppError::io(format!(
+            "Failed to create repair preserve directory {:?}: {}",
+            temp_dir, e
+        ))
+    })?;
+
+    let mut items = Vec::new();
+    for relative_path in preserve_relative_paths(preserve_scope) {
+        let source = data_dir.join(&relative_path);
+        if !source.exists() {
+            continue;
+        }
+
+        let temp_path = temp_dir.join(&relative_path);
+        copy_path(&source, &temp_path)?;
+        items.push(PreservedItem {
+            relative_path,
+            temp_path,
+        });
+    }
+
+    Ok(Some(PreservedData { temp_dir, items }))
+}
+
+fn preserve_relative_paths(preserve_scope: RepairPreserveScope) -> Vec<PathBuf> {
+    match preserve_scope {
+        RepairPreserveScope::DataDirectory => Vec::new(),
+        RepairPreserveScope::ConfigAndDataFiles => vec![
+            PathBuf::from("config"),
+            PathBuf::from("data_v4.db"),
+            PathBuf::from("cmd_config.json"),
+            PathBuf::from("mcp_server.json"),
+        ],
+        RepairPreserveScope::CoreConfigAndDataFiles => vec![
+            PathBuf::from("data_v4.db"),
+            PathBuf::from("cmd_config.json"),
+            PathBuf::from("mcp_server.json"),
+        ],
+        RepairPreserveScope::DatabaseOnly => vec![PathBuf::from("data_v4.db")],
+    }
+}
+
+fn copy_path(source: &Path, target: &Path) -> Result<()> {
+    let metadata = fs::metadata(source)
+        .map_err(|e| AppError::io(format!("Failed to read metadata {:?}: {}", source, e)))?;
+
+    if metadata.is_dir() {
+        copy_dir_recursive(source, target)?;
+    } else {
+        if let Some(parent) = target.parent() {
+            fs::create_dir_all(parent).map_err(|e| {
+                AppError::io(format!("Failed to create directory {:?}: {}", parent, e))
+            })?;
+        }
+        fs::copy(source, target).map_err(|e| {
+            AppError::io(format!(
+                "Failed to copy {:?} to {:?}: {}",
+                source, target, e
+            ))
+        })?;
+    }
+
+    Ok(())
+}
+
+fn copy_dir_recursive(source: &Path, target: &Path) -> Result<()> {
+    fs::create_dir_all(target)
+        .map_err(|e| AppError::io(format!("Failed to create directory {:?}: {}", target, e)))?;
+
+    for entry in fs::read_dir(source)
+        .map_err(|e| AppError::io(format!("Failed to read directory {:?}: {}", source, e)))?
+    {
+        let entry = entry.map_err(|e| AppError::io(e.to_string()))?;
+        let source_path = entry.path();
+        let target_path = target.join(entry.file_name());
+        let file_type = entry.file_type().map_err(|e| AppError::io(e.to_string()))?;
+
+        if file_type.is_dir() {
+            copy_dir_recursive(&source_path, &target_path)?;
+        } else if file_type.is_file() {
+            if let Some(parent) = target_path.parent() {
+                fs::create_dir_all(parent).map_err(|e| {
+                    AppError::io(format!("Failed to create directory {:?}: {}", parent, e))
+                })?;
+            }
+            fs::copy(&source_path, &target_path).map_err(|e| {
+                AppError::io(format!(
+                    "Failed to copy {:?} to {:?}: {}",
+                    source_path, target_path, e
+                ))
+            })?;
+        }
+    }
+
+    Ok(())
+}
+
+fn restore_preserved_data(core_dir: &Path, preserved: &PreservedData) -> Result<()> {
+    let data_dir = core_dir.join("data");
+    fs::create_dir_all(&data_dir)
+        .map_err(|e| AppError::io(format!("Failed to create data dir: {}", e)))?;
+
+    for item in &preserved.items {
+        copy_path(&item.temp_path, &data_dir.join(&item.relative_path))?;
+    }
+
+    Ok(())
+}
+
+fn remove_preserve_dir(temp_dir: &Path) {
+    if let Err(e) = fs::remove_dir_all(temp_dir) {
+        log::warn!(
+            "Failed to remove repair preserve directory {:?}: {}",
+            temp_dir,
+            e
+        );
+    }
+}
+
+fn clear_stale_preserve_dirs(instance_id: &str) {
+    let instance_dir = crate::utils::paths::get_instance_dir(instance_id);
+    let entries = match fs::read_dir(&instance_dir) {
+        Ok(entries) => entries,
+        Err(e) => {
+            if e.kind() != std::io::ErrorKind::NotFound {
+                log::warn!(
+                    "Failed to read instance directory {:?} before repair: {}",
+                    instance_dir,
+                    e
+                );
+            }
+            return;
+        }
+    };
+
+    for entry in entries {
+        let Ok(entry) = entry else {
+            continue;
+        };
+        let file_name = entry.file_name();
+        let Some(file_name) = file_name.to_str() else {
+            continue;
+        };
+        if !file_name.starts_with(".repair-preserve-") {
+            continue;
+        }
+
+        remove_preserve_dir(&entry.path());
+    }
+}
+
+fn clear_pycache_in_dirs(core_dir: &Path, venv_dir: &Path) -> Result<()> {
+    if core_dir.exists() {
+        super::cleanup::clear_pycache_recursive(core_dir)?;
+    }
+    if venv_dir.exists() {
+        super::cleanup::clear_pycache_recursive(venv_dir)?;
     }
 
     Ok(())

--- a/src-tauri/src/instance/mod.rs
+++ b/src-tauri/src/instance/mod.rs
@@ -24,3 +24,4 @@ pub use rebuild::{rebuild_instance_manifest_from_disk, RebuildInstanceManifestRe
 
 // Re-export cleanup
 pub use cleanup::{clear_instance_data, clear_instance_venv, clear_pycache};
+pub use deploy::{repair_instance, RepairPreserveScope};

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -137,6 +137,7 @@ pub fn run() {
             commands::clear_instance_data,
             commands::clear_instance_venv,
             commands::clear_pycache,
+            commands::repair_instance,
             commands::rebuild_instance_manifest,
             // Instance Management
             commands::create_instance,

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,5 +1,6 @@
 import { invoke } from '@tauri-apps/api/core';
 import type { GitHubRelease, AppSnapshot } from './types';
+import type { RepairPreserveScope } from './types';
 
 type LockCheckRequest =
   | {
@@ -79,6 +80,8 @@ export const api = {
     }),
   clearInstanceVenv: (instanceId: string) => invoke<void>('clear_instance_venv', { instanceId }),
   clearPycache: (instanceId: string) => invoke<void>('clear_pycache', { instanceId }),
+  repairInstance: (instanceId: string, preserveScope: RepairPreserveScope) =>
+    invoke<void>('repair_instance', { instanceId, preserveScope }),
   rebuildInstanceManifest: () =>
     invoke<{ instances: number; versions: number }>('rebuild_instance_manifest'),
 

--- a/src/components/advanced/RepairInstanceModal.tsx
+++ b/src/components/advanced/RepairInstanceModal.tsx
@@ -1,0 +1,96 @@
+import { Alert, Modal, Radio, Space, Typography } from 'antd';
+import type { RepairPreserveScope } from '../../types';
+
+const { Text } = Typography;
+
+interface RepairInstanceModalProps {
+  open: boolean;
+  loading: boolean;
+  preserveScope: RepairPreserveScope;
+  onScopeChange: (scope: RepairPreserveScope) => void;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+const PRESERVE_OPTIONS: Array<{
+  label: string;
+  value: RepairPreserveScope;
+  description: string;
+}> = [
+  {
+    label: 'data 目录',
+    value: 'data_directory',
+    description: '保留完整 data 目录，仅重装实例版本、重建 venv 并清空 Python 缓存。',
+  },
+  {
+    label: '数据库与配置文件',
+    value: 'config_and_data_files',
+    description: '保留 config、data_v4.db、cmd_config.json、mcp_server.json。',
+  },
+  {
+    label: '数据库与核心配置文件',
+    value: 'core_config_and_data_files',
+    description: '保留 data_v4.db、cmd_config.json、mcp_server.json。',
+  },
+  {
+    label: '仅数据库',
+    value: 'database_only',
+    description: '仅保留 data_v4.db。',
+  },
+];
+
+export function RepairInstanceModal({
+  open,
+  loading,
+  preserveScope,
+  onScopeChange,
+  onConfirm,
+  onCancel,
+}: RepairInstanceModalProps) {
+  const mayLoseData = preserveScope !== 'data_directory';
+
+  return (
+    <Modal
+      title="修复实例"
+      open={open}
+      okText="开始修复"
+      cancelText="取消"
+      onOk={onConfirm}
+      onCancel={onCancel}
+      okButtonProps={{ danger: mayLoseData, loading }}
+      cancelButtonProps={{ disabled: loading }}
+      closable={false}
+      mask={{ closable: !loading }}
+      keyboard={!loading}
+      width={560}
+    >
+      <Space orientation="vertical" size={16} style={{ width: '100%' }}>
+        <Radio.Group
+          value={preserveScope}
+          onChange={(event) => onScopeChange(event.target.value)}
+          disabled={loading}
+          style={{ width: '100%' }}
+        >
+          <Space orientation="vertical" size={12} style={{ width: '100%' }}>
+            {PRESERVE_OPTIONS.map((option) => (
+              <Radio key={option.value} value={option.value}>
+                <Space direction="vertical" size={2}>
+                  <Text>{option.label}</Text>
+                  <Text type="secondary">{option.description}</Text>
+                </Space>
+              </Radio>
+            ))}
+          </Space>
+        </Radio.Group>
+
+        {mayLoseData && (
+          <Alert
+            type="warning"
+            showIcon
+            message="修复后的实例可能会有数据丢失"
+          />
+        )}
+      </Space>
+    </Modal>
+  );
+}

--- a/src/components/advanced/TroubleshootingCard.tsx
+++ b/src/components/advanced/TroubleshootingCard.tsx
@@ -1,5 +1,5 @@
 import { Alert, Button, Card, Select, Space, Switch, Typography } from 'antd';
-import { PlayCircleOutlined, ReloadOutlined } from '@ant-design/icons';
+import { PlayCircleOutlined, ReloadOutlined, ToolOutlined } from '@ant-design/icons';
 
 const { Text } = Typography;
 
@@ -61,17 +61,21 @@ interface TroubleshootingCardProps {
   selectedDataInstance: string | null;
   selectedVenvInstance: string | null;
   selectedPycacheInstance: string | null;
+  selectedRepairInstance: string | null;
   confirmModal: 'clearData' | 'clearVenv' | 'clearPycache' | 'rebuildManifest' | null;
   clearDataLoading: boolean;
   clearVenvLoading: boolean;
   clearPycacheLoading: boolean;
+  repairInstanceLoading: boolean;
   rebuildManifestLoading: boolean;
   onSelectDataInstance: (id: string | null) => void;
   onSelectVenvInstance: (id: string | null) => void;
   onSelectPycacheInstance: (id: string | null) => void;
+  onSelectRepairInstance: (id: string | null) => void;
   onOpenClearData: () => void;
   onOpenClearVenv: () => void;
   onOpenClearPycache: () => void;
+  onOpenRepairInstance: () => void;
   onOpenRebuildManifest: () => void;
   onIgnoreExternalPathChange: (checked: boolean) => void;
 }
@@ -85,17 +89,21 @@ export function TroubleshootingCard({
   selectedDataInstance,
   selectedVenvInstance,
   selectedPycacheInstance,
+  selectedRepairInstance,
   confirmModal,
   clearDataLoading,
   clearVenvLoading,
   clearPycacheLoading,
+  repairInstanceLoading,
   rebuildManifestLoading,
   onSelectDataInstance,
   onSelectVenvInstance,
   onSelectPycacheInstance,
+  onSelectRepairInstance,
   onOpenClearData,
   onOpenClearVenv,
   onOpenClearPycache,
+  onOpenRepairInstance,
   onOpenRebuildManifest,
   onIgnoreExternalPathChange,
 }: TroubleshootingCardProps) {
@@ -169,6 +177,28 @@ export function TroubleshootingCard({
             disabled={confirmModal === 'clearPycache'}
             loading={clearPycacheLoading}
           />
+          <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
+            <Text style={{ width: 140 }}>修复实例:</Text>
+            <Select
+              style={{ width: 200 }}
+              placeholder="选择"
+              options={stoppedInstanceOptions}
+              onChange={onSelectRepairInstance}
+              value={selectedRepairInstance}
+              disabled={stoppedInstanceOptions.length === 0 || repairInstanceLoading}
+              allowClear
+            />
+            <Button
+              type="primary"
+              icon={<ToolOutlined />}
+              disabled={!selectedRepairInstance}
+              loading={repairInstanceLoading}
+              onClick={onOpenRepairInstance}
+            >
+              修复
+            </Button>
+            <Text type="secondary">重新安装版本、重新生成 venv、清空 Python 缓存</Text>
+          </div>
         </Space>
       </div>
 

--- a/src/constants/operationKeys.ts
+++ b/src/constants/operationKeys.ts
@@ -29,5 +29,6 @@ export const OPERATION_KEYS = {
   advancedClearData: (instanceId: string) => `adv:data-${instanceId}`,
   advancedClearVenv: (instanceId: string) => `adv:venv-${instanceId}`,
   advancedClearPycache: (instanceId: string) => `adv:pycache-${instanceId}`,
+  advancedRepairInstance: (instanceId: string) => `adv:repair-${instanceId}`,
   advancedRebuildInstanceManifest: 'adv:rebuild-instance-manifest',
 } as const;

--- a/src/pages/Advanced.tsx
+++ b/src/pages/Advanced.tsx
@@ -10,11 +10,13 @@ import { ConfirmModal } from '../components/ConfirmModal';
 import { GeneralSettingsCard } from '../components/advanced/GeneralSettingsCard';
 import { LockCheckConfirmModal } from '../components/LockCheckConfirmModal';
 import { ProxySettingsCard } from '../components/advanced/ProxySettingsCard';
+import { RepairInstanceModal } from '../components/advanced/RepairInstanceModal';
 import { SourceSettingsCard } from '../components/advanced/SourceSettingsCard';
 import { TroubleshootingCard } from '../components/advanced/TroubleshootingCard';
 import { PageHeader } from '../components/PageHeader';
 import { handleApiError } from '../utils';
 import { OPERATION_KEYS } from '../constants';
+import type { RepairPreserveScope } from '../types';
 import {
   normalizeInputValue,
   validateGithubProxy,
@@ -86,9 +88,13 @@ export default function Advanced() {
   const [selectedDataInstance, setSelectedDataInstance] = useState<string | null>(null);
   const [selectedVenvInstance, setSelectedVenvInstance] = useState<string | null>(null);
   const [selectedPycacheInstance, setSelectedPycacheInstance] = useState<string | null>(null);
+  const [selectedRepairInstance, setSelectedRepairInstance] = useState<string | null>(null);
+  const [repairPreserveScope, setRepairPreserveScope] =
+    useState<RepairPreserveScope>('data_directory');
 
   // Modal state
   const [confirmModal, setConfirmModal] = useState<ConfirmModalType>(null);
+  const [repairModalOpen, setRepairModalOpen] = useState(false);
   const { lockCheckModal, closeLockCheckModal, handleLockCheckError } =
     useLockCheckModal<LockCheckRetryPayload>();
 
@@ -457,6 +463,44 @@ export default function Advanced() {
     });
   };
 
+  const handleRepairInstance = async () => {
+    if (!selectedRepairInstance) return;
+
+    const instanceId = selectedRepairInstance;
+    await runOperation({
+      key: OPERATION_KEYS.advancedRepairInstance(instanceId),
+      reloadBefore: true,
+      reloadAfter: false,
+      task: async () => {
+        const { instances: latestInstances } = useAppStore.getState();
+        const latestInstance = findLatestOrSkip(
+          latestInstances,
+          (i) => i.id === instanceId,
+          '实例不存在或已被删除'
+        );
+        if (latestInstance === SKIP_OPERATION) {
+          setSelectedRepairInstance(null);
+          setRepairModalOpen(false);
+          return SKIP_OPERATION;
+        }
+
+        if (latestInstance.state !== 'stopped') {
+          message.warning('请先停止实例再修复');
+          return SKIP_OPERATION;
+        }
+
+        await api.repairInstance(instanceId, repairPreserveScope);
+      },
+      onSuccess: () => {
+        message.success('实例修复完成');
+        setSelectedRepairInstance(null);
+        setRepairPreserveScope('data_directory');
+        setRepairModalOpen(false);
+        void reloadSnapshot({ throwOnError: true });
+      },
+    });
+  };
+
   const instanceOptions = instances.map((i) => ({
     label: i.name,
     value: i.id,
@@ -478,6 +522,9 @@ export default function Advanced() {
     : false;
   const clearPycacheLoading = selectedPycacheInstance
     ? operations[OPERATION_KEYS.advancedClearPycache(selectedPycacheInstance)] || false
+    : false;
+  const repairInstanceLoading = selectedRepairInstance
+    ? operations[OPERATION_KEYS.advancedRepairInstance(selectedRepairInstance)] || false
     : false;
   const ignoreExternalPathSaving =
     operations[OPERATION_KEYS.advancedSaveIgnoreExternalPath] || false;
@@ -531,8 +578,7 @@ export default function Advanced() {
       case 'rebuildManifest':
         return {
           title: '警告',
-          content:
-            '确定扫描当前文件并重建实例清单？这会强制使用磁盘上数据生成实例清单。',
+          content: '确定扫描当前文件并重建实例清单？这会强制使用磁盘上数据生成实例清单。',
           onOk: () => void handleRebuildInstanceManifest(),
           isDanger: true,
         };
@@ -620,19 +666,32 @@ export default function Advanced() {
         selectedDataInstance={selectedDataInstance}
         selectedVenvInstance={selectedVenvInstance}
         selectedPycacheInstance={selectedPycacheInstance}
+        selectedRepairInstance={selectedRepairInstance}
         confirmModal={confirmModal}
         clearDataLoading={clearDataLoading}
         clearVenvLoading={clearVenvLoading}
         clearPycacheLoading={clearPycacheLoading}
+        repairInstanceLoading={repairInstanceLoading}
         rebuildManifestLoading={rebuildManifestLoading}
         onSelectDataInstance={setSelectedDataInstance}
         onSelectVenvInstance={setSelectedVenvInstance}
         onSelectPycacheInstance={setSelectedPycacheInstance}
+        onSelectRepairInstance={setSelectedRepairInstance}
         onOpenClearData={() => setConfirmModal('clearData')}
         onOpenClearVenv={() => setConfirmModal('clearVenv')}
         onOpenClearPycache={() => setConfirmModal('clearPycache')}
+        onOpenRepairInstance={() => setRepairModalOpen(true)}
         onOpenRebuildManifest={() => setConfirmModal('rebuildManifest')}
         onIgnoreExternalPathChange={handleIgnoreExternalPathChange}
+      />
+
+      <RepairInstanceModal
+        open={repairModalOpen}
+        loading={repairInstanceLoading}
+        preserveScope={repairPreserveScope}
+        onScopeChange={setRepairPreserveScope}
+        onConfirm={() => void handleRepairInstance()}
+        onCancel={() => setRepairModalOpen(false)}
       />
 
       {/* Confirm Modal */}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -161,6 +161,12 @@ export interface DeployProgress {
 
 export type DeployType = 'start' | 'upgrade' | 'downgrade' | null;
 
+export type RepairPreserveScope =
+  | 'data_directory'
+  | 'config_and_data_files'
+  | 'core_config_and_data_files'
+  | 'database_only';
+
 export interface DeployState {
   instanceName: string;
   deployType: 'start' | 'upgrade' | 'downgrade';


### PR DESCRIPTION
Introduce functionality to repair an instance by re-deploying it from its installed version while allowing selective data preservation, rebuilding the virtual environment, and clearing the Python cache. This enhancement improves instance management capabilities.

## Summary by Sourcery

Add an advanced repair flow that reinstalls an instance from its installed version while supporting selective data preservation and cleanup.

New Features:
- Introduce backend repair_instance command that redeploys an instance with configurable data preservation scopes and clears Python caches.
- Expose instance repair as an advanced UI action with a dedicated modal for choosing preservation scope and tracking operation state.

Enhancements:
- Refactor pycache cleanup utilities for reuse by the new repair workflow.