### PR TITLE
feat: assign child processes to Windows Job Object with kill-on-close

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -62,9 +62,11 @@ webkit2gtk = "2"
 windows = { version = "0.61.2", features = [
     "Win32_System_Threading",
     "Win32_System_Console",
+    "Win32_System_JobObjects",
     "Win32_System_RestartManager",
     "Win32_System_Registry",
     "Win32_Foundation",
+    "Win32_Security",
     "Win32_NetworkManagement_IpHelper",
     "Win32_Networking_WinSock",
 ] }

--- a/src-tauri/src/instance/lifecycle.rs
+++ b/src-tauri/src/instance/lifecycle.rs
@@ -213,7 +213,13 @@ pub async fn launch_instance(
         .id()
         .ok_or_else(|| AppError::process("Failed to get process ID"))?;
     #[cfg(target_os = "windows")]
-    let job_object = assign_child_to_job_object(pid)?;
+    let job_object = match assign_child_to_job_object(pid) {
+        Ok(job_object) => job_object,
+        Err(e) => {
+            let _ = child.kill().await;
+            return Err(e);
+        }
+    };
     let executable_path = resolve_child_executable_path(&mut child, pid).await?;
 
     let stdout = child

--- a/src-tauri/src/instance/lifecycle.rs
+++ b/src-tauri/src/instance/lifecycle.rs
@@ -44,6 +44,8 @@ pub struct LaunchResult {
     pub executable_path: PathBuf,
     pub port: u16,
     pub dashboard_enabled: bool,
+    #[cfg(target_os = "windows")]
+    pub job_object: crate::process::JobObject,
 }
 
 fn cancel_startup_due_to_shutdown(
@@ -67,6 +69,13 @@ fn cancel_startup_due_to_shutdown(
     Err(AppError::process(format!(
         "Cannot start instance {instance_id}: application is shutting down"
     )))
+}
+
+#[cfg(target_os = "windows")]
+fn assign_child_to_job_object(pid: u32) -> Result<crate::process::JobObject> {
+    let job_object = crate::process::JobObject::create_kill_on_close()?;
+    job_object.assign_process_by_pid(pid)?;
+    Ok(job_object)
 }
 
 /// Resolve the executable path for a freshly spawned child, killing it on failure.
@@ -203,6 +212,8 @@ pub async fn launch_instance(
     let pid = child
         .id()
         .ok_or_else(|| AppError::process("Failed to get process ID"))?;
+    #[cfg(target_os = "windows")]
+    let job_object = assign_child_to_job_object(pid)?;
     let executable_path = resolve_child_executable_path(&mut child, pid).await?;
 
     let stdout = child
@@ -295,6 +306,8 @@ pub async fn launch_instance(
                 executable_path,
                 port,
                 dashboard_enabled,
+                #[cfg(target_os = "windows")]
+                job_object,
             })
         }
         exit_result = &mut exit_rx => {

--- a/src-tauri/src/process/manager.rs
+++ b/src-tauri/src/process/manager.rs
@@ -416,6 +416,8 @@ impl ProcessManager {
                         launch.executable_path,
                         launch.port,
                         launch.dashboard_enabled,
+                        #[cfg(target_os = "windows")]
+                        launch.job_object,
                     )));
                 }
                 drop(state);

--- a/src-tauri/src/process/mod.rs
+++ b/src-tauri/src/process/mod.rs
@@ -20,6 +20,8 @@ pub use control::{
     graceful_shutdown, is_expected_process_alive, resolve_process_executable_path,
 };
 pub use manager::ProcessManager;
+#[cfg(target_os = "windows")]
+pub(crate) use win_api::JobObject;
 
 /// Timeout (in seconds) for waiting for the startup log message.
 pub const STARTUP_TIMEOUT_SECS: u64 = 300;
@@ -68,6 +70,8 @@ pub struct InstanceProcess {
     pub executable_path: PathBuf,
     pub port: u16,
     pub dashboard_enabled: bool,
+    #[cfg(target_os = "windows")]
+    pub(crate) _job_object: JobObject,
     /// Number of consecutive failed liveness probes.
     /// Always 0 on non-Windows (no retry mechanism).
     pub(crate) alive_failure_count: u32,
@@ -98,12 +102,15 @@ impl InstanceProcess {
         executable_path: PathBuf,
         port: u16,
         dashboard_enabled: bool,
+        #[cfg(target_os = "windows")] job_object: JobObject,
     ) -> Self {
         Self {
             pid,
             executable_path,
             port,
             dashboard_enabled,
+            #[cfg(target_os = "windows")]
+            _job_object: job_object,
             alive_failure_count: 0,
             next_alive_check_at: None,
         }

--- a/src-tauri/src/process/mod.rs
+++ b/src-tauri/src/process/mod.rs
@@ -70,6 +70,9 @@ pub struct InstanceProcess {
     pub executable_path: PathBuf,
     pub port: u16,
     pub dashboard_enabled: bool,
+    /// Keeps the Windows job handle alive while the instance is tracked. When
+    /// the slot is removed, dropping this handle lets KILL_ON_JOB_CLOSE clean up
+    /// any remaining processes in the job.
     #[cfg(target_os = "windows")]
     pub(crate) _job_object: JobObject,
     /// Number of consecutive failed liveness probes.

--- a/src-tauri/src/process/win_api.rs
+++ b/src-tauri/src/process/win_api.rs
@@ -50,9 +50,14 @@ pub struct JobObject {
     inner: Arc<Owned<HANDLE>>,
 }
 
-// Windows kernel handles are valid across threads in the owning process. The
-// `windows` crate keeps HANDLE as a raw pointer and does not auto-mark it
-// Send/Sync, so the process manager's shared state needs this wrapper boundary.
+// Safety invariants:
+// - JobObject only owns launcher-created job handles in this process.
+// - The handle is placed in `Owned<HANDLE>` immediately after creation and is
+//   never exposed outside this type, so it is closed exactly once when the last
+//   Arc clone is dropped.
+// - Windows kernel handles are valid across threads in the owning process.
+//   The `windows` crate represents HANDLE as a raw pointer and does not mark it
+//   Send/Sync, so the process manager needs this wrapper boundary.
 unsafe impl Send for JobObject {}
 unsafe impl Sync for JobObject {}
 
@@ -63,13 +68,14 @@ impl JobObject {
         let handle = unsafe { CreateJobObjectW(None, PCWSTR::null()) }.map_err(|e| {
             crate::error::AppError::process(format!("Failed to create job object: {e}"))
         })?;
+        let handle = unsafe { Owned::new(handle) };
 
         let mut limits = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
         limits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
 
         unsafe {
             SetInformationJobObject(
-                handle,
+                *handle,
                 JobObjectExtendedLimitInformation,
                 std::ptr::addr_of!(limits).cast::<c_void>(),
                 std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
@@ -82,7 +88,7 @@ impl JobObject {
         })?;
 
         Ok(Self {
-            inner: Arc::new(unsafe { Owned::new(handle) }),
+            inner: Arc::new(handle),
         })
     }
 
@@ -97,15 +103,15 @@ impl JobObject {
                     ))
                 },
             )?;
+        let process_handle = unsafe { Owned::new(process_handle) };
 
         let result =
-            unsafe { AssignProcessToJobObject(**self.inner, process_handle) }.map_err(|e| {
+            unsafe { AssignProcessToJobObject(**self.inner, *process_handle) }.map_err(|e| {
                 crate::error::AppError::process(format!(
                     "Failed to assign PID {pid} to job object: {e}"
                 ))
             });
 
-        let _ = unsafe { CloseHandle(process_handle) };
         result
     }
 }

--- a/src-tauri/src/process/win_api.rs
+++ b/src-tauri/src/process/win_api.rs
@@ -1,28 +1,35 @@
 //! Windows native API helpers for process management.
 
 use std::collections::HashSet;
+use std::ffi::c_void;
 use std::ffi::OsString;
 use std::fmt;
 use std::os::windows::ffi::{OsStrExt as _, OsStringExt as _};
 use std::path::PathBuf;
+use std::sync::Arc;
 
-use windows::core::{PCWSTR, PWSTR};
+use windows::core::{Owned, PCWSTR, PWSTR};
 use windows::Win32::Foundation::{
     CloseHandle, ERROR_INSUFFICIENT_BUFFER, ERROR_MAX_SESSIONS_REACHED, ERROR_MORE_DATA,
-    ERROR_SUCCESS, NO_ERROR, STILL_ACTIVE, WIN32_ERROR,
+    ERROR_SUCCESS, HANDLE, NO_ERROR, STILL_ACTIVE, WIN32_ERROR,
 };
 use windows::Win32::NetworkManagement::IpHelper::{
     GetExtendedTcpTable, MIB_TCP6ROW_OWNER_PID, MIB_TCP6TABLE_OWNER_PID, MIB_TCPROW_OWNER_PID,
     MIB_TCPTABLE_OWNER_PID, TCP_TABLE_OWNER_PID_LISTENER,
 };
 use windows::Win32::Networking::WinSock::{AF_INET, AF_INET6};
+use windows::Win32::System::JobObjects::{
+    AssignProcessToJobObject, CreateJobObjectW, JobObjectExtendedLimitInformation,
+    SetInformationJobObject, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
+    JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+};
 use windows::Win32::System::RestartManager::{
     RmEndSession, RmGetList, RmRegisterResources, RmStartSession, CCH_RM_SESSION_KEY,
     RM_PROCESS_INFO,
 };
 use windows::Win32::System::Threading::{
     GetExitCodeProcess, OpenProcess, QueryFullProcessImageNameW, PROCESS_NAME_FORMAT,
-    PROCESS_QUERY_LIMITED_INFORMATION,
+    PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_SET_QUOTA, PROCESS_TERMINATE,
 };
 
 /// Maximum number of retries when the TCP table changes between size query and data fetch.
@@ -36,6 +43,71 @@ pub struct LockingProcessInfo {
     pub app_name: String,
     pub service_short_name: String,
     pub executable_path: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone)]
+pub struct JobObject {
+    inner: Arc<Owned<HANDLE>>,
+}
+
+// Windows kernel handles are valid across threads in the owning process. The
+// `windows` crate keeps HANDLE as a raw pointer and does not auto-mark it
+// Send/Sync, so the process manager's shared state needs this wrapper boundary.
+unsafe impl Send for JobObject {}
+unsafe impl Sync for JobObject {}
+
+impl JobObject {
+    /// Create a Windows Job Object that terminates all assigned processes when
+    /// the final launcher-owned job handle is closed.
+    pub fn create_kill_on_close() -> crate::error::Result<Self> {
+        let handle = unsafe { CreateJobObjectW(None, PCWSTR::null()) }.map_err(|e| {
+            crate::error::AppError::process(format!("Failed to create job object: {e}"))
+        })?;
+
+        let mut limits = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
+        limits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+
+        unsafe {
+            SetInformationJobObject(
+                handle,
+                JobObjectExtendedLimitInformation,
+                std::ptr::addr_of!(limits).cast::<c_void>(),
+                std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+            )
+        }
+        .map_err(|e| {
+            crate::error::AppError::process(format!(
+                "Failed to configure job object kill-on-close: {e}"
+            ))
+        })?;
+
+        Ok(Self {
+            inner: Arc::new(unsafe { Owned::new(handle) }),
+        })
+    }
+
+    /// Assign a process to this job object using the access rights required by
+    /// `AssignProcessToJobObject`: PROCESS_SET_QUOTA and PROCESS_TERMINATE.
+    pub fn assign_process_by_pid(&self, pid: u32) -> crate::error::Result<()> {
+        let process_handle =
+            unsafe { OpenProcess(PROCESS_SET_QUOTA | PROCESS_TERMINATE, false, pid) }.map_err(
+                |e| {
+                    crate::error::AppError::process(format!(
+                        "Failed to open PID {pid} for job object assignment: {e}"
+                    ))
+                },
+            )?;
+
+        let result =
+            unsafe { AssignProcessToJobObject(**self.inner, process_handle) }.map_err(|e| {
+                crate::error::AppError::process(format!(
+                    "Failed to assign PID {pid} to job object: {e}"
+                ))
+            });
+
+        let _ = unsafe { CloseHandle(process_handle) };
+        result
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]


### PR DESCRIPTION
Ensure bot instances are terminated when the launcher exits on Windows by assigning each spawned process to a Job Object configured with JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE. When the last launcher-held job handle is closed (process record removed or app exit), the kernel automatically terminates all associated child processes, preventing orphaned bot instances.

## Summary by Sourcery

Assign Windows-launched bot processes to a kill-on-close Job Object to ensure they are terminated when the launcher exits.

New Features:
- Introduce a Windows Job Object wrapper that configures JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE and supports assigning processes by PID.
- Track a per-instance Job Object in launch and process lifecycle data so child processes remain associated with the launcher for their lifetime.

Enhancements:
- Extend Windows-specific process management dependencies to support Job Objects and required security capabilities.