### PR TITLE
feat: add quick open core folder action

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -483,10 +483,9 @@ pub async fn open_instance_core_folder(app_handle: AppHandle, instance_id: Strin
     let core_dir = get_instance_core_dir(&instance_id);
 
     if !core_dir.is_dir() {
-        return Err(AppError::io(format!(
-            "Instance core folder does not exist: {}",
-            core_dir.display()
-        )));
+        return Err(AppError::other(
+            "实例 core 文件夹不存在，可以尝试先运行一次实例后再打开。",
+        ));
     }
 
     app_handle

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -3,7 +3,7 @@ use std::sync::RwLock;
 
 use reqwest::Client;
 use tauri::{AppHandle, State};
-use tauri_plugin_opener::OpenerExt as _;
+use tauri_plugin_opener::open_path;
 
 use crate::backup;
 use crate::component;
@@ -478,7 +478,7 @@ pub async fn rebuild_instance_manifest(
 // === Instance Management ===
 
 #[tauri::command]
-pub async fn open_instance_core_folder(app_handle: AppHandle, instance_id: String) -> Result<()> {
+pub async fn open_instance_core_folder(instance_id: String) -> Result<()> {
     validate_instance_id(&instance_id)?;
     let core_dir = get_instance_core_dir(&instance_id);
 
@@ -488,10 +488,7 @@ pub async fn open_instance_core_folder(app_handle: AppHandle, instance_id: Strin
         ));
     }
 
-    app_handle
-        .opener()
-        .open_path(core_dir.to_string_lossy().into_owned(), None::<&str>)
-        .map_err(|e| AppError::io(e.to_string()))
+    open_path(&core_dir, None::<&str>).map_err(|e| AppError::io(e.to_string()))
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -3,6 +3,7 @@ use std::sync::RwLock;
 
 use reqwest::Client;
 use tauri::{AppHandle, State};
+use tauri_plugin_opener::OpenerExt as _;
 
 use crate::backup;
 use crate::component;
@@ -475,6 +476,24 @@ pub async fn rebuild_instance_manifest(
 }
 
 // === Instance Management ===
+
+#[tauri::command]
+pub async fn open_instance_core_folder(app_handle: AppHandle, instance_id: String) -> Result<()> {
+    validate_instance_id(&instance_id)?;
+    let core_dir = get_instance_core_dir(&instance_id);
+
+    if !core_dir.is_dir() {
+        return Err(AppError::io(format!(
+            "Instance core folder does not exist: {}",
+            core_dir.display()
+        )));
+    }
+
+    app_handle
+        .opener()
+        .open_path(core_dir.to_string_lossy().into_owned(), None::<&str>)
+        .map_err(|e| AppError::io(e.to_string()))
+}
 
 #[tauri::command]
 pub async fn create_instance(name: String, version: String, port: u16) -> Result<()> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -140,6 +140,7 @@ pub fn run() {
             commands::repair_instance,
             commands::rebuild_instance_manifest,
             // Instance Management
+            commands::open_instance_core_folder,
             commands::create_instance,
             commands::delete_instance,
             commands::update_instance,

--- a/src/api.ts
+++ b/src/api.ts
@@ -88,6 +88,8 @@ export const api = {
   // ========================================
   // Instance Management
   // ========================================
+  openInstanceCoreFolder: (instanceId: string) =>
+    invoke<void>('open_instance_core_folder', { instanceId }),
   createInstance: (name: string, version: string, port: number = 0) =>
     invoke<void>('create_instance', { name, version, port }),
   deleteInstance: (instanceId: string) => invoke<void>('delete_instance', { instanceId }),

--- a/src/components/InstanceActions.tsx
+++ b/src/components/InstanceActions.tsx
@@ -4,6 +4,7 @@ import {
   PauseCircleOutlined,
   ReloadOutlined,
   DeleteOutlined,
+  FolderOpenOutlined,
   GlobalOutlined,
   SettingOutlined,
 } from '@ant-design/icons';
@@ -19,6 +20,7 @@ interface InstanceActionsProps {
   onStop: (id: string) => void;
   onRestart: (id: string) => void;
   onOpen: (instance: InstanceStatus) => void;
+  onOpenCoreFolder: (instance: InstanceStatus) => void;
   onEdit: (instance: InstanceStatus) => void;
   onDelete: (instance: InstanceStatus) => void;
 }
@@ -33,6 +35,7 @@ export function InstanceActions({
   onStop,
   onRestart,
   onOpen,
+  onOpenCoreFolder,
   onEdit,
   onDelete,
 }: InstanceActionsProps) {
@@ -93,6 +96,14 @@ export function InstanceActions({
           />
         </Tooltip>
       )}
+      <Tooltip title="打开 core 文件夹">
+        <Button
+          type="text"
+          icon={<FolderOpenOutlined />}
+          disabled={isDeleting}
+          onClick={() => onOpenCoreFolder(instance)}
+        />
+      </Tooltip>
       <Tooltip title="设置">
         <Button
           type="text"

--- a/src/components/InstanceActions.tsx
+++ b/src/components/InstanceActions.tsx
@@ -100,7 +100,7 @@ export function InstanceActions({
         <Button
           type="text"
           icon={<FolderOpenOutlined />}
-          disabled={isDeleting}
+          disabled={isDeploying || isDeleting}
           onClick={() => onOpenCoreFolder(instance)}
         />
       </Tooltip>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -389,6 +389,20 @@ export default function Dashboard() {
     [navigate]
   );
 
+  const handleOpenCoreFolder = useCallback(async (instance: InstanceStatus) => {
+    const { instances: latestInstances } = useAppStore.getState();
+    if (!latestInstances.some((i) => i.id === instance.id)) {
+      message.info('实例不存在或已被删除');
+      return;
+    }
+
+    try {
+      await api.openInstanceCoreFolder(instance.id);
+    } catch (error) {
+      handleApiError(error, '打开 core 文件夹失败');
+    }
+  }, []);
+
   const openEditModal = useCallback((instance: InstanceStatus) => {
     setEditingInstance(instance);
     setEditOpen(true);
@@ -414,6 +428,7 @@ export default function Dashboard() {
         onStop: handleStop,
         onRestart: handleRestart,
         onOpen: handleOpen,
+        onOpenCoreFolder: handleOpenCoreFolder,
         onEdit: openEditModal,
         onDelete: openDeleteModal,
       }),
@@ -430,6 +445,7 @@ export default function Dashboard() {
       handleStop,
       handleRestart,
       handleOpen,
+      handleOpenCoreFolder,
       openEditModal,
       openDeleteModal,
     ]

--- a/src/pages/dashboardColumns.tsx
+++ b/src/pages/dashboardColumns.tsx
@@ -19,6 +19,7 @@ interface DashboardColumnsOptions {
   onStop: (id: string) => void;
   onRestart: (id: string) => void;
   onOpen: (instance: InstanceStatus) => void;
+  onOpenCoreFolder: (instance: InstanceStatus) => void;
   onEdit: (instance: InstanceStatus) => void;
   onDelete: (instance: InstanceStatus) => void;
 }
@@ -36,6 +37,7 @@ export function buildDashboardColumns({
   onStop,
   onRestart,
   onOpen,
+  onOpenCoreFolder,
   onEdit,
   onDelete,
 }: DashboardColumnsOptions): TableColumnsType<InstanceStatus> {
@@ -44,13 +46,14 @@ export function buildDashboardColumns({
       title: '名称',
       dataIndex: 'name',
       key: 'name',
+      ellipsis: true,
       render: (text: string) => <strong>{text}</strong>,
     },
     {
       title: '状态',
       dataIndex: 'state',
       key: 'state',
-      width: 180,
+      width: 120,
       render: (_: string, record: InstanceStatus) => (
         <InstanceStatusTag instance={record} deployProgress={deployProgress} />
       ),
@@ -69,8 +72,7 @@ export function buildDashboardColumns({
       title: '版本',
       dataIndex: 'version',
       key: 'version',
-      width: 150,
-      ellipsis: true,
+      width: 120,
       render: (version: string, record: InstanceStatus) => (
         <Space size={4}>
           <span>{version}</span>
@@ -87,7 +89,7 @@ export function buildDashboardColumns({
     {
       title: '操作',
       key: 'action',
-      width: 240,
+      width: 280,
       render: (_: unknown, record: InstanceStatus) => {
         const deploying = isInstanceDeploying(record.id, deployProgress);
 
@@ -102,6 +104,7 @@ export function buildDashboardColumns({
             onStop={onStop}
             onRestart={onRestart}
             onOpen={onOpen}
+            onOpenCoreFolder={onOpenCoreFolder}
             onEdit={onEdit}
             onDelete={onDelete}
           />


### PR DESCRIPTION
## Summary by Sourcery

Add a dashboard action and backend command to open an instance's core folder directly from the UI.

New Features:
- Allow users to open an instance's core folder via a new dashboard action wired to a Tauri command.

Enhancements:
- Adjust dashboard table column widths and enable name ellipsis to better accommodate the new action button.