### PR TITLE
feat: add view logs button to instance list

### DIFF
--- a/src/components/InstanceActions.tsx
+++ b/src/components/InstanceActions.tsx
@@ -7,6 +7,7 @@ import {
   FolderOpenOutlined,
   GlobalOutlined,
   SettingOutlined,
+  FileTextOutlined,
 } from '@ant-design/icons';
 import type { InstanceStatus } from '../types';
 
@@ -23,6 +24,7 @@ interface InstanceActionsProps {
   onOpenCoreFolder: (instance: InstanceStatus) => void;
   onEdit: (instance: InstanceStatus) => void;
   onDelete: (instance: InstanceStatus) => void;
+  onViewLogs: (instance: InstanceStatus) => void;
 }
 
 export function InstanceActions({
@@ -38,6 +40,7 @@ export function InstanceActions({
   onOpenCoreFolder,
   onEdit,
   onDelete,
+  onViewLogs,
 }: InstanceActionsProps) {
   const isActive = instance.state !== 'stopped';
   const canOpenWebUI =
@@ -102,6 +105,14 @@ export function InstanceActions({
           icon={<FolderOpenOutlined />}
           disabled={isDeploying || isDeleting}
           onClick={() => onOpenCoreFolder(instance)}
+        />
+      </Tooltip>
+      <Tooltip title="查看日志">
+        <Button
+          type="text"
+          icon={<FileTextOutlined />}
+          disabled={isDeploying || isDeleting}
+          onClick={() => onViewLogs(instance)}
         />
       </Tooltip>
       <Tooltip title="设置">

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -421,6 +421,13 @@ export default function Dashboard() {
     setDeleteOpen(true);
   }, []);
 
+  const handleViewLogs = useCallback(
+    (instance: InstanceStatus) => {
+      navigate(`/logs?source=${instance.id}`);
+    },
+    [navigate]
+  );
+
   const columns = useMemo(
     () =>
       buildDashboardColumns({
@@ -439,6 +446,7 @@ export default function Dashboard() {
         onOpenCoreFolder: handleOpenCoreFolder,
         onEdit: openEditModal,
         onDelete: openDeleteModal,
+        onViewLogs: handleViewLogs,
       }),
     [
       deployProgress,
@@ -456,6 +464,7 @@ export default function Dashboard() {
       handleOpenCoreFolder,
       openEditModal,
       openDeleteModal,
+      handleViewLogs,
     ]
   );
 

--- a/src/pages/Logs.tsx
+++ b/src/pages/Logs.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { Button, Card, Empty, Select, Flex, Layout } from 'antd';
 import { ClearOutlined } from '@ant-design/icons';
 import Ansi from 'ansi-to-react';
@@ -17,11 +18,14 @@ const levelOptions: { label: string; value: LogLevel }[] = [
 ];
 
 export default function Logs() {
+  const [searchParams] = useSearchParams();
   const instances = useAppStore((s) => s.instances);
   const getFilteredLogs = useLogStore((s) => s.getFilteredLogs);
   const clearLogs = useLogStore((s) => s.clearLogs);
 
-  const [source, setSource] = useState<string>('system');
+  const [source, setSource] = useState<string>(() => {
+    return searchParams.get('source') ?? 'system';
+  });
   const [level, setLevel] = useState<LogLevel>('info');
   const containerRef = useRef<HTMLElement>(null);
   const shouldAutoScroll = useRef(true);

--- a/src/pages/dashboardColumns.tsx
+++ b/src/pages/dashboardColumns.tsx
@@ -22,6 +22,7 @@ interface DashboardColumnsOptions {
   onOpenCoreFolder: (instance: InstanceStatus) => void;
   onEdit: (instance: InstanceStatus) => void;
   onDelete: (instance: InstanceStatus) => void;
+  onViewLogs: (instance: InstanceStatus) => void;
 }
 
 export function buildDashboardColumns({
@@ -40,6 +41,7 @@ export function buildDashboardColumns({
   onOpenCoreFolder,
   onEdit,
   onDelete,
+  onViewLogs,
 }: DashboardColumnsOptions): TableColumnsType<InstanceStatus> {
   return [
     {
@@ -89,7 +91,7 @@ export function buildDashboardColumns({
     {
       title: '操作',
       key: 'action',
-      width: 280,
+      width: 320,
       render: (_: unknown, record: InstanceStatus) => {
         const deploying = isInstanceDeploying(record.id, deployProgress);
 
@@ -107,6 +109,7 @@ export function buildDashboardColumns({
             onOpenCoreFolder={onOpenCoreFolder}
             onEdit={onEdit}
             onDelete={onDelete}
+            onViewLogs={onViewLogs}
           />
         );
       },


### PR DESCRIPTION
Add a "view logs" button in the instance actions column that navigates to the logs page with the instance pre-selected as the log source via URL query parameter. Widen the actions column to accommodate the new button.

## Summary by Sourcery

Add a logs view action to instances and support deep-linking to the logs page with a preselected source.

New Features:
- Add a "view logs" action to each instance in the dashboard instance list that opens the logs page for that instance.
- Allow the logs page to initialize the selected log source from a URL query parameter.

Enhancements:
- Increase the width of the instance actions column to accommodate the new logs button.