### PR TITLE
feat: detect and notify default credentials from instance stdout

### DIFF
--- a/src-tauri/src/instance/lifecycle.rs
+++ b/src-tauri/src/instance/lifecycle.rs
@@ -6,7 +6,8 @@
 use std::path::{Path, PathBuf};
 use std::process::ExitStatus;
 
-use tauri::AppHandle;
+use serde::Serialize;
+use tauri::{AppHandle, Emitter as _};
 use tokio::io::{AsyncBufReadExt as _, BufReader};
 use tokio::process::Command;
 use tokio::sync::{mpsc, oneshot, watch};
@@ -31,11 +32,82 @@ use crate::utils::validation::validate_instance_id;
 use crate::process::STARTUP_TIMEOUT_SECS;
 
 const STARTUP_COMPLETION_MARKERS: &[&str] = &["AstrBot started.", "AstrBot 启动完成"];
+const DEFAULT_USERNAME_LABEL: &str = "Initial username";
+const DEFAULT_PASSWORD_LABEL: &str = "Initial password";
+const CREDENTIAL_VALUE_PREFIXES: &[&str] = &[":", "："];
+#[derive(Clone, Serialize)]
+struct DefaultCredentialsDetected {
+    source: String,
+    display_name: String,
+    username: String,
+    password: String,
+}
+
+#[derive(Default)]
+struct DefaultCredentialsDetector {
+    username: Option<String>,
+    password: Option<String>,
+}
 
 fn is_startup_completion_log(line: &str) -> bool {
     STARTUP_COMPLETION_MARKERS
         .iter()
         .any(|marker| line.contains(marker))
+}
+
+fn clean_credential_value(raw_value: &str) -> Option<String> {
+    let mut value = raw_value.trim_start();
+
+    for prefix in CREDENTIAL_VALUE_PREFIXES {
+        if let Some(rest) = value.trim_start().strip_prefix(prefix) {
+            value = rest;
+            break;
+        }
+    }
+
+    let token = value
+        .trim_start()
+        .split_whitespace()
+        .next()?
+        .trim_matches(|ch| matches!(ch, '"' | '\'' | '`' | ',' | '，' | '。' | ';' | '；'));
+
+    (!token.is_empty()).then(|| token.to_string())
+}
+
+fn extract_credential_value(line: &str, label: &str) -> Option<String> {
+    let label_index = line.find(label)?;
+    clean_credential_value(&line[label_index + label.len()..])
+}
+
+impl DefaultCredentialsDetector {
+    fn push_line(
+        &mut self,
+        source: &str,
+        display_name: &str,
+        line: &str,
+    ) -> Option<DefaultCredentialsDetected> {
+        if let Some(username) = extract_credential_value(line, DEFAULT_USERNAME_LABEL) {
+            self.username = Some(username);
+        }
+
+        if let Some(password) = extract_credential_value(&line, DEFAULT_PASSWORD_LABEL) {
+            self.password = Some(password);
+        }
+
+        if self.username.is_none() || self.password.is_none() {
+            return None;
+        }
+
+        let username = self.username.take()?;
+        let password = self.password.take()?;
+
+        Some(DefaultCredentialsDetected {
+            source: source.to_string(),
+            display_name: display_name.to_string(),
+            username,
+            password,
+        })
+    }
 }
 
 /// Result of a successful instance launch.
@@ -296,12 +368,20 @@ pub async fn launch_instance(
     // Keep one sender in scope so receiver does not close early if stdout ends.
     let _startup_tx_guard = startup_tx.clone();
     let instance_id_stdout = instance_id.to_string();
+    let instance_name = instance_config.name.clone();
+    let app_handle_stdout = app_handle.clone();
     let mut stdout_reader = BufReader::new(stdout).lines();
 
     tokio::spawn(async move {
         let mut startup_sent = false;
+        let mut credentials_detector = DefaultCredentialsDetector::default();
         while let Ok(Some(line)) = stdout_reader.next_line().await {
             log_channel::emit_log(&instance_id_stdout, "info", &line);
+            if let Some(credentials) =
+                credentials_detector.push_line(&instance_id_stdout, &instance_name, &line)
+            {
+                let _ = app_handle_stdout.emit("default-credentials-detected", credentials);
+            }
             if !startup_sent && is_startup_completion_log(&line) {
                 let _ = startup_tx.send(());
                 startup_sent = true;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,17 @@
 import { BrowserRouter, Routes, Route, useNavigate, useLocation } from 'react-router-dom';
 import { lazy, Suspense, useEffect, useMemo } from 'react';
-import { Badge, Layout, Menu, ConfigProvider, App as AntdApp, theme } from 'antd';
+import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+import {
+  Badge,
+  Button,
+  Layout,
+  Menu,
+  ConfigProvider,
+  App as AntdApp,
+  Space,
+  Typography,
+  theme,
+} from 'antd';
 import zhCN from 'antd/locale/zh_CN';
 import {
   DesktopOutlined,
@@ -12,8 +23,9 @@ import {
 } from '@ant-design/icons';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { TitleBar } from './components/TitleBar';
-import { AntdStaticProvider } from './antdStatic';
+import { AntdStaticProvider, message } from './antdStatic';
 import { useAppStore, useUpdateStore, initEventListeners, cleanupEventListeners } from './stores';
+import type { DefaultCredentialsDetected } from './types';
 const Dashboard = lazy(() => import('./pages/Dashboard'));
 const Versions = lazy(() => import('./pages/Versions'));
 const Backup = lazy(() => import('./pages/Backup'));
@@ -28,6 +40,71 @@ const UPDATE_INTERVAL_MS = 16 * 60 * 60 * 1000;
 
 // Height of the custom titlebar. Must stay in sync with .titlebar { height } in App.css.
 const TITLEBAR_HEIGHT = 40;
+
+function hashMessageKey(value: string): string {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(36);
+}
+
+function showDefaultCredentialsMessage(credentials: DefaultCredentialsDetected) {
+  if (!credentials.username || !credentials.password) return;
+
+  const messageKey = `default-credentials-${hashMessageKey(
+    `${credentials.source}\n${credentials.username}\n${credentials.password}`
+  )}`;
+
+  message.open({
+    key: messageKey,
+    type: 'info',
+    duration: 0,
+    content: (
+      <Space direction="vertical" size={4}>
+        <Typography.Text strong>{credentials.display_name} 默认账户密码</Typography.Text>
+        <Typography.Text>
+          用户名: <Typography.Text code>{credentials.username}</Typography.Text>
+        </Typography.Text>
+        <Typography.Text>
+          密码: <Typography.Text code>{credentials.password}</Typography.Text>
+        </Typography.Text>
+        <Button size="small" onClick={() => message.destroy(messageKey)}>
+          我已知晓
+        </Button>
+      </Space>
+    ),
+  });
+}
+
+function DefaultCredentialsListener() {
+  useEffect(() => {
+    let unlisten: UnlistenFn | null = null;
+    let disposed = false;
+
+    const setupListener = async () => {
+      const fn = await listen<DefaultCredentialsDetected>('default-credentials-detected', (event) =>
+        showDefaultCredentialsMessage(event.payload)
+      );
+
+      if (disposed) {
+        fn();
+        return;
+      }
+      unlisten = fn;
+    };
+
+    void setupListener();
+
+    return () => {
+      disposed = true;
+      unlisten?.();
+    };
+  }, []);
+
+  return null;
+}
 
 function AppLayout() {
   const navigate = useNavigate();
@@ -165,6 +242,7 @@ function App({ isMacOS }: { isMacOS: boolean }) {
           {!isMacOS && <TitleBar />}
           <div style={{ flex: 1, height: 0, minHeight: 0, overflow: 'hidden' }}>
             <BrowserRouter>
+              <DefaultCredentialsListener />
               <Suspense>
                 <Routes>
                   <Route path="/webui/:instanceId" element={<WebUIView />} />

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -182,6 +182,13 @@ export interface LogEntry {
   timestamp: string;
 }
 
+export interface DefaultCredentialsDetected {
+  source: string;
+  display_name: string;
+  username: string;
+  password: string;
+}
+
 // ========================================
 // UI Types
 // ========================================


### PR DESCRIPTION
Parse instance stdout for default username/password labels and emit a Tauri event when detected. The frontend displays a persistent notification with the credentials so users can copy them without browsing logs.

## Summary by Sourcery

Detect default instance credentials from stdout logs and notify the frontend via a Tauri event so users see them as a persistent in‑app message.

New Features:
- Parse instance stdout for initial username and password labels and track detected default credentials.
- Emit a `default-credentials-detected` Tauri event when both username and password have been identified for an instance.
- Display a persistent UI notification containing the detected default credentials, allowing users to view them without inspecting logs.

Enhancements:
- Strip ANSI color codes and clean credential values from stdout lines to robustly extract usable username and password tokens.
- Introduce a shared `DefaultCredentialsDetected` type for strongly typed communication between backend events and the frontend listener.