### PR TITLE
fix: only accept "astrbot" username to avoid out-of-order credential detection

### DIFF
--- a/src-tauri/src/instance/lifecycle.rs
+++ b/src-tauri/src/instance/lifecycle.rs
@@ -34,6 +34,7 @@ use crate::process::STARTUP_TIMEOUT_SECS;
 const STARTUP_COMPLETION_MARKERS: &[&str] = &["AstrBot started.", "AstrBot 启动完成"];
 const DEFAULT_USERNAME_LABEL: &str = "Initial username";
 const DEFAULT_PASSWORD_LABEL: &str = "Initial password";
+const DEFAULT_EXPECTED_USERNAME: &str = "astrbot";
 const CREDENTIAL_VALUE_PREFIXES: &[&str] = &[":", "："];
 #[derive(Clone, Serialize)]
 struct DefaultCredentialsDetected {
@@ -80,18 +81,31 @@ fn extract_credential_value(line: &str, label: &str) -> Option<String> {
 }
 
 impl DefaultCredentialsDetector {
+    /// Process a single stdout line from the instance.
+    ///
+    /// Workaround: the username must match the expected default "astrbot"
+    /// before we capture the password. This prevents out-of-order field
+    /// detection from picking up unrelated credential-like output.
     fn push_line(
         &mut self,
         source: &str,
         display_name: &str,
         line: &str,
     ) -> Option<DefaultCredentialsDetected> {
-        if let Some(username) = extract_credential_value(line, DEFAULT_USERNAME_LABEL) {
-            self.username = Some(username);
+        // Only accept username if it matches the known default.
+        if self.username.is_none() {
+            if let Some(username) = extract_credential_value(line, DEFAULT_USERNAME_LABEL) {
+                if username == DEFAULT_EXPECTED_USERNAME {
+                    self.username = Some(username);
+                }
+            }
         }
 
-        if let Some(password) = extract_credential_value(&line, DEFAULT_PASSWORD_LABEL) {
-            self.password = Some(password);
+        // Only look for password after confirming username.
+        if self.username.is_some() {
+            if let Some(password) = extract_credential_value(line, DEFAULT_PASSWORD_LABEL) {
+                self.password = Some(password);
+            }
         }
 
         if self.username.is_none() || self.password.is_none() {

--- a/src-tauri/src/instance/lifecycle.rs
+++ b/src-tauri/src/instance/lifecycle.rs
@@ -94,11 +94,8 @@ impl DefaultCredentialsDetector {
     ) -> Option<DefaultCredentialsDetected> {
         // Only accept username if it matches the known default.
         if self.username.is_none() {
-            if let Some(username) = extract_credential_value(line, DEFAULT_USERNAME_LABEL) {
-                if username == DEFAULT_EXPECTED_USERNAME {
-                    self.username = Some(username);
-                }
-            }
+            self.username = extract_credential_value(line, DEFAULT_USERNAME_LABEL)
+                .filter(|username| username == DEFAULT_EXPECTED_USERNAME);
         }
 
         // Only look for password after confirming username.


### PR DESCRIPTION
Before this fix, DefaultCredentialsDetector would capture any credential-like output regardless of field order or value. This could pick up unrelated username/password pairs if the instance stdout contained other credential-like text before the real default credentials.

Now the detector verifies the username matches the expected default "astrbot" before proceeding to capture the password. This ensures correct field association even when lines arrive in unpredictable order.

## Summary by Sourcery

Bug Fixes:
- Ensure default credential detection ignores non-astrbot usernames and only captures passwords after confirming the expected default username.