### PR TITLE
feat: add dark mode

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -10,7 +10,7 @@ use crate::component;
 use crate::component::ComponentsSnapshot;
 use crate::config::{
     load_config, load_manifest, reload_config, reload_manifest, with_config_mut, AppConfig,
-    AppManifest, BackupInfo, InstalledVersion,
+    AppManifest, BackupInfo, InstalledVersion, ThemePreference,
 };
 use crate::download;
 use crate::error::{AppError, Result};
@@ -285,6 +285,11 @@ define_save_config_command!(
     save_lock_check_extension_whitelist,
     lock_check_extension_whitelist: bool,
     lock_check_extension_whitelist
+);
+define_save_config_command!(
+    save_theme_preference,
+    theme_preference: ThemePreference,
+    theme_preference
 );
 
 // === Components ===

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -23,6 +23,15 @@ fn default_instance_host() -> String {
     DEFAULT_INSTANCE_HOST.to_string()
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ThemePreference {
+    #[default]
+    System,
+    Light,
+    Dark,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AppConfig {
     #[serde(default)]
@@ -55,6 +64,8 @@ pub struct AppConfig {
     pub ignore_external_path: bool,
     #[serde(default)]
     pub lock_check_extension_whitelist: bool,
+    #[serde(default)]
+    pub theme_preference: ThemePreference,
 }
 
 impl Default for AppConfig {
@@ -75,6 +86,7 @@ impl Default for AppConfig {
             persist_instance_state: false,
             ignore_external_path: false,
             lock_check_extension_whitelist: false,
+            theme_preference: ThemePreference::System,
         }
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -121,6 +121,7 @@ pub fn run() {
             commands::save_persist_instance_state,
             commands::save_ignore_external_path,
             commands::save_lock_check_extension_whitelist,
+            commands::save_theme_preference,
             commands::save_mainland_acceleration,
             commands::is_macos,
             // Components

--- a/src-tauri/src/migration/config_manifest.rs
+++ b/src-tauri/src/migration/config_manifest.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::config::{
     has_config_record, has_manifest_record, with_config_mut, with_manifest_mut, AppConfig,
-    AppManifest, InstalledVersion, InstanceConfig,
+    AppManifest, InstalledVersion, InstanceConfig, ThemePreference,
 };
 use crate::utils::paths::{config_path, manifest_path};
 
@@ -56,6 +56,8 @@ struct LegacyAppConfig {
     ignore_external_path: bool,
     #[serde(default)]
     tracked_instances_snapshot: Vec<String>,
+    #[serde(default)]
+    theme_preference: ThemePreference,
 }
 
 impl LegacyAppConfig {
@@ -76,6 +78,7 @@ impl LegacyAppConfig {
             persist_instance_state: self.persist_instance_state,
             ignore_external_path: self.ignore_external_path,
             lock_check_extension_whitelist: false,
+            theme_preference: self.theme_preference,
         }
     }
 

--- a/src/App.css
+++ b/src/App.css
@@ -1,17 +1,40 @@
 :root {
+  --app-bg: #f5f5f5;
+  --app-text: #333;
+  --app-text-secondary: #666;
+  --app-titlebar-bg: #fff;
+  --app-titlebar-shadow: rgba(0, 0, 0, 0.06);
+  --app-titlebar-btn-hover-bg: rgba(0, 0, 0, 0.06);
+  --app-titlebar-btn-active-bg: rgba(0, 0, 0, 0.1);
+  --app-scrollbar-thumb: rgba(0, 0, 0, 0.15);
+  --app-scrollbar-thumb-hover: rgba(0, 0, 0, 0.25);
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
   font-size: 14px;
   line-height: 1.5;
-  color: #333;
-  background-color: #f5f5f5;
+  color: var(--app-text);
+  background-color: var(--app-bg);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+:root[data-theme='dark'] {
+  --app-bg: #000;
+  --app-text: rgba(255, 255, 255, 0.85);
+  --app-text-secondary: rgba(255, 255, 255, 0.65);
+  --app-titlebar-bg: #141414;
+  --app-titlebar-shadow: rgba(255, 255, 255, 0.08);
+  --app-titlebar-btn-hover-bg: rgba(255, 255, 255, 0.08);
+  --app-titlebar-btn-active-bg: rgba(255, 255, 255, 0.14);
+  --app-scrollbar-thumb: rgba(255, 255, 255, 0.18);
+  --app-scrollbar-thumb-hover: rgba(255, 255, 255, 0.3);
 }
 
 body {
   margin: 0;
   padding: 0;
   overflow: hidden;
+  color: var(--app-text);
+  background: var(--app-bg);
 }
 
 * {
@@ -29,12 +52,12 @@ body {
 }
 
 ::-webkit-scrollbar-thumb {
-  background: rgba(0, 0, 0, 0.15);
+  background: var(--app-scrollbar-thumb);
   border-radius: 3px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: rgba(0, 0, 0, 0.25);
+  background: var(--app-scrollbar-thumb-hover);
 }
 
 /* Title bar */
@@ -43,8 +66,8 @@ body {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  background: #fff;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+  background: var(--app-titlebar-bg);
+  box-shadow: 0 1px 3px var(--app-titlebar-shadow);
   user-select: none;
   flex-shrink: 0;
   position: relative;
@@ -55,7 +78,7 @@ body {
   padding-left: 16px;
   font-weight: 600;
   font-size: 13px;
-  color: #555;
+  color: var(--app-text);
   letter-spacing: 0.3px;
 }
 
@@ -73,18 +96,18 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  color: #666;
+  color: var(--app-text-secondary);
   transition: background 0.15s, color 0.15s;
   outline: none;
 }
 
 .titlebar-btn:hover {
-  background: rgba(0, 0, 0, 0.06);
-  color: #333;
+  background: var(--app-titlebar-btn-hover-bg);
+  color: var(--app-text);
 }
 
 .titlebar-btn:active {
-  background: rgba(0, 0, 0, 0.1);
+  background: var(--app-titlebar-btn-active-bg);
 }
 
 .titlebar-btn-close:hover {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ import { ErrorBoundary } from './components/ErrorBoundary';
 import { TitleBar } from './components/TitleBar';
 import { AntdStaticProvider, message } from './antdStatic';
 import { useAppStore, useUpdateStore, initEventListeners, cleanupEventListeners } from './stores';
+import { useResolvedTheme } from './hooks';
 import type { DefaultCredentialsDetected } from './types';
 const Dashboard = lazy(() => import('./pages/Dashboard'));
 const Versions = lazy(() => import('./pages/Versions'));
@@ -109,6 +110,7 @@ function DefaultCredentialsListener() {
 function AppLayout() {
   const navigate = useNavigate();
   const location = useLocation();
+  const { token } = theme.useToken();
   const reloadSnapshot = useAppStore((s) => s.reloadSnapshot);
   const hasUpdate = useUpdateStore((s) => s.hasUpdate);
 
@@ -158,14 +160,22 @@ function AppLayout() {
 
   return (
     <div style={{ height: '100%', minHeight: 0, display: 'flex', flexDirection: 'column' }}>
-      <Layout style={{ flex: 1, minHeight: 0, overflow: 'hidden' }}>
+      <Layout
+        style={{
+          flex: 1,
+          minHeight: 0,
+          overflow: 'hidden',
+          background: token.colorBgLayout,
+        }}
+      >
         <Sider
           width={180}
-          theme="light"
           style={{
             overflow: 'auto',
             height: '100%',
             minHeight: 0,
+            background: token.colorBgContainer,
+            borderRight: `1px solid ${token.colorBorderSecondary}`,
           }}
         >
           <Menu
@@ -173,11 +183,19 @@ function AppLayout() {
             selectedKeys={[location.pathname]}
             items={menuItems}
             onClick={({ key }) => navigate(key)}
-            style={{ borderRight: 0 }}
+            style={{ borderRight: 0, background: token.colorBgContainer }}
           />
         </Sider>
-        <Layout style={{ minHeight: 0 }}>
-          <Content style={{ padding: 24, overflow: 'auto', height: '100%', minHeight: 0 }}>
+        <Layout style={{ minHeight: 0, background: token.colorBgLayout }}>
+          <Content
+            style={{
+              padding: 24,
+              overflow: 'auto',
+              height: '100%',
+              minHeight: 0,
+              background: token.colorBgLayout,
+            }}
+          >
             <ErrorBoundary>
               <Routes>
                 <Route path="/" element={<Dashboard />} />
@@ -196,6 +214,8 @@ function AppLayout() {
 }
 
 function App({ isMacOS }: { isMacOS: boolean }) {
+  const resolvedTheme = useResolvedTheme();
+
   useEffect(() => {
     void initEventListeners();
     void useAppStore.getState().reloadSnapshot();
@@ -211,6 +231,11 @@ function App({ isMacOS }: { isMacOS: boolean }) {
     };
   }, []);
 
+  useEffect(() => {
+    document.documentElement.dataset.theme = resolvedTheme;
+    document.documentElement.style.colorScheme = resolvedTheme;
+  }, [resolvedTheme]);
+
   // On non-macOS, a custom titlebar occupies the top TITLEBAR_HEIGHT px.
   // All Ant Design overlays that render via portals (Drawer, message, notification)
   // are offset below the titlebar so interactive elements are never hidden behind it.
@@ -222,7 +247,7 @@ function App({ isMacOS }: { isMacOS: boolean }) {
     <ConfigProvider
       locale={zhCN}
       theme={{
-        algorithm: theme.defaultAlgorithm,
+        algorithm: resolvedTheme === 'dark' ? theme.darkAlgorithm : theme.defaultAlgorithm,
         token: {
           borderRadius: 8,
         },

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,5 +1,5 @@
 import { invoke } from '@tauri-apps/api/core';
-import type { GitHubRelease, AppSnapshot } from './types';
+import type { GitHubRelease, AppSnapshot, ThemePreference } from './types';
 import type { RepairPreserveScope } from './types';
 
 type LockCheckRequest =
@@ -46,6 +46,8 @@ export const api = {
     invoke<void>('save_mainland_acceleration', { mainlandAcceleration }),
   saveLockCheckExtensionWhitelist: (lockCheckExtensionWhitelist: boolean) =>
     invoke<void>('save_lock_check_extension_whitelist', { lockCheckExtensionWhitelist }),
+  saveThemePreference: (themePreference: ThemePreference) =>
+    invoke<void>('save_theme_preference', { themePreference }),
 
   // ========================================
   // Components

--- a/src/components/advanced/GeneralSettingsCard.tsx
+++ b/src/components/advanced/GeneralSettingsCard.tsx
@@ -1,5 +1,5 @@
 import { Card, Form, Select, Switch } from 'antd';
-import type { AppConfig } from '../../types';
+import type { AppConfig, ThemePreference } from '../../types';
 
 interface GeneralSettingsCardProps {
   config: AppConfig | null;
@@ -8,6 +8,7 @@ interface GeneralSettingsCardProps {
   useUvSaving: boolean;
   mainlandAccelerationSaving: boolean;
   lockCheckExtensionWhitelistSaving: boolean;
+  themePreferenceSaving: boolean;
   onCloseToTrayChange: (value: string) => void;
   onCheckInstanceUpdateChange: (checked: boolean) => void;
   onPersistInstanceStateChange: (checked: boolean) => void;
@@ -15,6 +16,7 @@ interface GeneralSettingsCardProps {
   onUseUvForDepsChange: (checked: boolean) => void;
   onMainlandAccelerationChange: (checked: boolean) => void;
   onLockCheckExtensionWhitelistChange: (checked: boolean) => void;
+  onThemePreferenceChange: (value: ThemePreference) => void;
 }
 
 export function GeneralSettingsCard({
@@ -24,6 +26,7 @@ export function GeneralSettingsCard({
   useUvSaving,
   mainlandAccelerationSaving,
   lockCheckExtensionWhitelistSaving,
+  themePreferenceSaving,
   onCloseToTrayChange,
   onCheckInstanceUpdateChange,
   onPersistInstanceStateChange,
@@ -31,10 +34,25 @@ export function GeneralSettingsCard({
   onUseUvForDepsChange,
   onMainlandAccelerationChange,
   onLockCheckExtensionWhitelistChange,
+  onThemePreferenceChange,
 }: GeneralSettingsCardProps) {
   return (
     <Card title="通用" size="small" style={{ marginBottom: 16 }}>
       <Form layout="vertical">
+        <Form.Item label="外观主题" extra="选择界面使用浅色、深色，或跟随系统设置">
+          <Select<ThemePreference>
+            value={config?.theme_preference ?? 'system'}
+            onChange={onThemePreferenceChange}
+            loading={themePreferenceSaving}
+            disabled={themePreferenceSaving}
+            options={[
+              { label: '跟随系统', value: 'system' },
+              { label: '浅色', value: 'light' },
+              { label: '深色', value: 'dark' },
+            ]}
+            style={{ width: 200 }}
+          />
+        </Form.Item>
         <Form.Item label="关闭窗口时" extra="选择关闭窗口按钮的行为">
           <Select
             value={config?.close_to_tray ? 'tray' : 'exit'}

--- a/src/constants/operationKeys.ts
+++ b/src/constants/operationKeys.ts
@@ -26,6 +26,7 @@ export const OPERATION_KEYS = {
   advancedSaveAutostart: 'adv:save-autostart',
   advancedSaveUseUvForDeps: 'adv:save-use-uv-for-deps',
   advancedSaveLockCheckExtensionWhitelist: 'adv:save-lock-check-extension-whitelist',
+  advancedSaveThemePreference: 'adv:save-theme-preference',
   advancedClearData: (instanceId: string) => `adv:data-${instanceId}`,
   advancedClearVenv: (instanceId: string) => `adv:venv-${instanceId}`,
   advancedClearPycache: (instanceId: string) => `adv:pycache-${instanceId}`,

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,3 +1,4 @@
 export { useOperationRunner, SKIP_OPERATION } from './useOperationRunner';
 export { findLatestOrSkip } from './operationGuards';
 export { useLockCheckModal } from './useLockCheckModal';
+export { useResolvedTheme } from './useResolvedTheme';

--- a/src/hooks/useResolvedTheme.ts
+++ b/src/hooks/useResolvedTheme.ts
@@ -4,19 +4,31 @@ import type { ResolvedTheme, ThemePreference } from '../types';
 
 const DARK_SCHEME_QUERY = '(prefers-color-scheme: dark)';
 
+const getDefaultTheme = (): ResolvedTheme => 'light';
+const subscribeToNoop = () => () => {};
+
 function getSystemTheme(): ResolvedTheme {
-  if (typeof window === 'undefined') {
-    return 'light';
+  if (typeof window === 'undefined' || !window.matchMedia) {
+    return getDefaultTheme();
   }
 
   return window.matchMedia(DARK_SCHEME_QUERY).matches ? 'dark' : 'light';
 }
 
 function subscribeToSystemTheme(onStoreChange: () => void) {
+  if (typeof window === 'undefined' || !window.matchMedia) {
+    return subscribeToNoop();
+  }
+
   const mediaQuery = window.matchMedia(DARK_SCHEME_QUERY);
 
-  mediaQuery.addEventListener('change', onStoreChange);
-  return () => mediaQuery.removeEventListener('change', onStoreChange);
+  if (typeof mediaQuery.addEventListener === 'function') {
+    mediaQuery.addEventListener('change', onStoreChange);
+    return () => mediaQuery.removeEventListener('change', onStoreChange);
+  }
+
+  mediaQuery.addListener(onStoreChange);
+  return () => mediaQuery.removeListener(onStoreChange);
 }
 
 function resolveTheme(
@@ -32,10 +44,11 @@ function resolveTheme(
 
 export function useResolvedTheme(): ResolvedTheme {
   const themePreference = useAppStore((s) => s.config?.theme_preference ?? 'system');
+  const shouldResolveSystemTheme = themePreference === 'system';
   const systemTheme = useSyncExternalStore<ResolvedTheme>(
-    subscribeToSystemTheme,
-    getSystemTheme,
-    () => 'light'
+    shouldResolveSystemTheme ? subscribeToSystemTheme : subscribeToNoop,
+    shouldResolveSystemTheme ? getSystemTheme : getDefaultTheme,
+    getDefaultTheme
   );
 
   return resolveTheme(themePreference, systemTheme);

--- a/src/hooks/useResolvedTheme.ts
+++ b/src/hooks/useResolvedTheme.ts
@@ -1,0 +1,42 @@
+import { useSyncExternalStore } from 'react';
+import { useAppStore } from '../stores';
+import type { ResolvedTheme, ThemePreference } from '../types';
+
+const DARK_SCHEME_QUERY = '(prefers-color-scheme: dark)';
+
+function getSystemTheme(): ResolvedTheme {
+  if (typeof window === 'undefined') {
+    return 'light';
+  }
+
+  return window.matchMedia(DARK_SCHEME_QUERY).matches ? 'dark' : 'light';
+}
+
+function subscribeToSystemTheme(onStoreChange: () => void) {
+  const mediaQuery = window.matchMedia(DARK_SCHEME_QUERY);
+
+  mediaQuery.addEventListener('change', onStoreChange);
+  return () => mediaQuery.removeEventListener('change', onStoreChange);
+}
+
+function resolveTheme(
+  themePreference: ThemePreference | undefined,
+  systemTheme: ResolvedTheme
+): ResolvedTheme {
+  if (themePreference === 'dark' || themePreference === 'light') {
+    return themePreference;
+  }
+
+  return systemTheme;
+}
+
+export function useResolvedTheme(): ResolvedTheme {
+  const themePreference = useAppStore((s) => s.config?.theme_preference ?? 'system');
+  const systemTheme = useSyncExternalStore<ResolvedTheme>(
+    subscribeToSystemTheme,
+    getSystemTheme,
+    () => 'light'
+  );
+
+  return resolveTheme(themePreference, systemTheme);
+}

--- a/src/pages/Advanced.tsx
+++ b/src/pages/Advanced.tsx
@@ -16,7 +16,7 @@ import { TroubleshootingCard } from '../components/advanced/TroubleshootingCard'
 import { PageHeader } from '../components/PageHeader';
 import { handleApiError } from '../utils';
 import { OPERATION_KEYS } from '../constants';
-import type { RepairPreserveScope } from '../types';
+import type { RepairPreserveScope, ThemePreference } from '../types';
 import {
   normalizeInputValue,
   validateGithubProxy,
@@ -65,6 +65,7 @@ export default function Advanced() {
   const loading = useAppStore((s) => s.loading);
   const reloadSnapshot = useAppStore((s) => s.reloadSnapshot);
   const rebuildSnapshotFromDisk = useAppStore((s) => s.rebuildSnapshotFromDisk);
+  const setThemePreference = useAppStore((s) => s.setThemePreference);
   const operations = useAppStore((s) => s.operations);
   const { runOperation } = useOperationRunner();
 
@@ -328,6 +329,18 @@ export default function Advanced() {
     });
   };
 
+  const handleThemePreferenceChange = async (value: ThemePreference) => {
+    await runOperation({
+      key: OPERATION_KEYS.advancedSaveThemePreference,
+      reloadAfter: false,
+      task: () => api.saveThemePreference(value),
+      onSuccess: () => {
+        setThemePreference(value);
+        message.success('设置已保存');
+      },
+    });
+  };
+
   const handleClearInstance = async ({
     selectedId,
     operationKey,
@@ -532,6 +545,7 @@ export default function Advanced() {
     operations[OPERATION_KEYS.advancedRebuildInstanceManifest] || false;
   const lockCheckExtensionWhitelistSaving =
     operations[OPERATION_KEYS.advancedSaveLockCheckExtensionWhitelist] || false;
+  const themePreferenceSaving = operations[OPERATION_KEYS.advancedSaveThemePreference] || false;
   const lockCheckModalLoading =
     lockCheckModal?.mode === 'checkFailed'
       ? operations[lockCheckModal.payload.operationKey] || false
@@ -604,6 +618,7 @@ export default function Advanced() {
         useUvSaving={useUvSaving}
         mainlandAccelerationSaving={mainlandAccelerationSaving}
         lockCheckExtensionWhitelistSaving={lockCheckExtensionWhitelistSaving}
+        themePreferenceSaving={themePreferenceSaving}
         onCloseToTrayChange={handleCloseToTrayChange}
         onCheckInstanceUpdateChange={handleCheckInstanceUpdateChange}
         onPersistInstanceStateChange={handlePersistInstanceStateChange}
@@ -611,6 +626,7 @@ export default function Advanced() {
         onUseUvForDepsChange={handleUseUvForDepsChange}
         onMainlandAccelerationChange={handleMainlandAccelerationChange}
         onLockCheckExtensionWhitelistChange={handleLockCheckExtensionWhitelistChange}
+        onThemePreferenceChange={handleThemePreferenceChange}
       />
 
       <ProxySettingsCard

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useEffect, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Button, Table, Modal, Form, Input, InputNumber, Select, Alert } from 'antd';
+import { Button, Table, Modal, Form, Input, InputNumber, Select, Alert, Typography } from 'antd';
 import { PlusOutlined } from '@ant-design/icons';
 import { api } from '../api';
 import { message } from '../antdStatic';
@@ -567,7 +567,9 @@ export default function Dashboard() {
         content={
           <>
             <p>确定要删除此实例吗？</p>
-            {instanceToDelete && <p style={{ color: '#666' }}>实例名称: {instanceToDelete.name}</p>}
+            {instanceToDelete && (
+              <Typography.Text type="secondary">实例名称: {instanceToDelete.name}</Typography.Text>
+            )}
           </>
         }
         loading={operations[OPERATION_KEYS.deleteInstance]}

--- a/src/pages/Logs.tsx
+++ b/src/pages/Logs.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { Button, Card, Empty, Select, Flex, Layout } from 'antd';
+import { Button, Card, Empty, Select, Flex, Layout, Typography } from 'antd';
 import { ClearOutlined } from '@ant-design/icons';
 import Ansi from 'ansi-to-react';
 import { PageHeader } from '../components/PageHeader';
@@ -62,14 +62,14 @@ export default function Logs() {
       <PageHeader title="日志" />
 
       <Flex align="center" gap={8} style={{ marginBottom: 12 }}>
-        <span style={{ color: '#666' }}>来源</span>
+        <Typography.Text type="secondary">来源</Typography.Text>
         <Select
           style={{ width: 200 }}
           value={effectiveSource}
           options={sourceOptions}
           onChange={setSource}
         />
-        <span style={{ color: '#666' }}>级别</span>
+        <Typography.Text type="secondary">级别</Typography.Text>
         <Select style={{ width: 120 }} value={level} options={levelOptions} onChange={setLevel} />
         <Flex flex={1} />
         <Button

--- a/src/pages/Versions.tsx
+++ b/src/pages/Versions.tsx
@@ -423,9 +423,7 @@ export default function Versions() {
         content={
           <>
             <p>确定删除此版本？</p>
-            {versionToUninstall && (
-              <p style={{ color: '#666' }}>版本: {versionToUninstall.version}</p>
-            )}
+            {versionToUninstall && <Text type="secondary">版本: {versionToUninstall.version}</Text>}
           </>
         }
         loading={

--- a/src/pages/WebUIView.tsx
+++ b/src/pages/WebUIView.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { Button, Spin } from 'antd';
+import { Button, Spin, Typography, theme } from 'antd';
 import { ArrowLeftOutlined } from '@ant-design/icons';
 import { api } from '../api';
 import { handleApiError } from '../utils';
@@ -8,6 +8,7 @@ import { handleApiError } from '../utils';
 export default function WebUIView() {
   const { instanceId } = useParams<{ instanceId: string }>();
   const navigate = useNavigate();
+  const { token } = theme.useToken();
   const [port, setPort] = useState<number | null>(null);
   const [loading, setLoading] = useState(true);
 
@@ -46,7 +47,12 @@ export default function WebUIView() {
         <Button icon={<ArrowLeftOutlined />} onClick={() => navigate('/')}>
           返回
         </Button>
-        <div style={{ textAlign: 'center', marginTop: 48, color: '#999' }}>无法获取实例端口</div>
+        <Typography.Text
+          type="secondary"
+          style={{ display: 'block', textAlign: 'center', marginTop: 48 }}
+        >
+          无法获取实例端口
+        </Typography.Text>
       </div>
     );
   }
@@ -59,8 +65,8 @@ export default function WebUIView() {
           display: 'flex',
           alignItems: 'center',
           padding: '0 12px',
-          borderBottom: '1px solid #f0f0f0',
-          background: '#fff',
+          borderBottom: `1px solid ${token.colorBorderSecondary}`,
+          background: token.colorBgContainer,
           gap: 8,
           flexShrink: 0,
         }}
@@ -68,7 +74,9 @@ export default function WebUIView() {
         <Button type="text" size="small" icon={<ArrowLeftOutlined />} onClick={() => navigate('/')}>
           返回
         </Button>
-        <span style={{ color: '#999', fontSize: 12 }}>http://localhost:{port}</span>
+        <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+          http://localhost:{port}
+        </Typography.Text>
       </div>
       <iframe
         src={`http://localhost:${port}`}

--- a/src/stores/useAppStore.ts
+++ b/src/stores/useAppStore.ts
@@ -12,6 +12,7 @@ import type {
   ComponentStatus,
   DownloadProgress,
   LogEntry,
+  ThemePreference,
 } from '../types';
 import { handleApiError } from '../utils';
 import { MODAL_CLOSE_DELAY_MS } from '../constants';
@@ -47,6 +48,7 @@ interface AppState {
   setDeployProgress: (progress: DeployProgress | null) => void;
   closeDeploy: () => void;
   clearDownloadProgress: (id: string) => void;
+  setThemePreference: (themePreference: ThemePreference) => void;
 }
 
 const KNOWN_COMPONENTS: ReadonlyArray<
@@ -257,6 +259,21 @@ export const useAppStore = create<AppState>((set, get) => {
         const next = { ...state.downloadProgress };
         delete next[id];
         return { downloadProgress: next };
+      });
+    },
+
+    setThemePreference: (themePreference: ThemePreference) => {
+      set((state) => {
+        if (!state.config) {
+          return state;
+        }
+
+        return {
+          config: {
+            ...state.config,
+            theme_preference: themePreference,
+          },
+        };
       });
     },
   };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,6 +11,9 @@ export interface AppError {
 // App Configuration Types
 // ========================================
 
+export type ThemePreference = 'system' | 'light' | 'dark';
+export type ResolvedTheme = 'light' | 'dark';
+
 export interface AppConfig {
   mainland_acceleration: boolean;
   github_proxy: string;
@@ -27,6 +30,7 @@ export interface AppConfig {
   persist_instance_state: boolean;
   ignore_external_path: boolean;
   lock_check_extension_whitelist: boolean;
+  theme_preference: ThemePreference;
 }
 
 // ========================================


### PR DESCRIPTION
Introduce a dark mode option that allows users to select their theme preference. This includes updates to configuration types, state management, and UI components to support theme resolution based on user settings or system preferences.

## Summary by Sourcery

Add configurable light/dark theming with system preference support across the desktop app UI.

New Features:
- Introduce a theme preference setting (system, light, dark) persisted in app configuration and exposed in advanced general settings.
- Resolve the active theme from user preference and system color scheme to drive Ant Design theming and global CSS variables for dark mode.

Enhancements:
- Refine layout, sidebar, content, and embedded web UI styling to use Ant Design tokens instead of hard-coded colors for better theme consistency.
- Replace hard-coded secondary text colors with Typography.Text to automatically adapt to the active theme.