### PR TITLE
fix: permission policy violation in instance webui iframe

### DIFF
--- a/src/pages/WebUIView.tsx
+++ b/src/pages/WebUIView.tsx
@@ -87,7 +87,7 @@ export default function WebUIView() {
           width: '100%',
         }}
         title="AstrBot WebUI"
-        allow="clipboard-write"
+        allow="clipboard-write; microphone; autoplay"
       />
     </div>
   );

--- a/src/pages/WebUIView.tsx
+++ b/src/pages/WebUIView.tsx
@@ -87,6 +87,7 @@ export default function WebUIView() {
           width: '100%',
         }}
         title="AstrBot WebUI"
+        allow="clipboard-write"
       />
     </div>
   );


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Grant clipboard-write permission to the AstrBot WebUI iframe to resolve clipboard API permission policy errors.