### PR TITLE
fix: prevent window from shrinking below minimum size on restore

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -29,6 +29,51 @@ pub use error::{AppError, ErrorKind, Result};
 use process::ProcessManager;
 use utils::log_bus::LogEntry;
 
+pub(crate) const MIN_WINDOW_WIDTH: u32 = 1000;
+pub(crate) const MIN_WINDOW_HEIGHT: u32 = 680;
+
+fn validate_window_state() {
+    let state_path = match dirs::config_dir() {
+        Some(d) => d
+            .join("com.github.raven95676.astrbot-launcher")
+            .join(".window-state.json"),
+        None => return,
+    };
+
+    let content = match std::fs::read_to_string(&state_path) {
+        Ok(c) => c,
+        Err(_) => return,
+    };
+
+    let mut value: serde_json::Value = match serde_json::from_str(&content) {
+        Ok(v) => v,
+        Err(_) => return,
+    };
+
+    let mut modified = false;
+
+    if let Some(main) = value.get_mut("main") {
+        if let Some(width) = main.get("width").and_then(|v| v.as_u64()) {
+            if width < MIN_WINDOW_WIDTH as u64 {
+                main["width"] = serde_json::json!(MIN_WINDOW_WIDTH);
+                modified = true;
+            }
+        }
+        if let Some(height) = main.get("height").and_then(|v| v.as_u64()) {
+            if height < MIN_WINDOW_HEIGHT as u64 {
+                main["height"] = serde_json::json!(MIN_WINDOW_HEIGHT);
+                modified = true;
+            }
+        }
+    }
+
+    if modified {
+        if let Ok(json) = serde_json::to_string_pretty(&value) {
+            let _ = std::fs::write(&state_path, json);
+        }
+    }
+}
+
 #[allow(clippy::expect_used)]
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -41,6 +86,7 @@ pub fn run() {
     utils::paths::ensure_data_dirs().expect("Failed to create data directories");
     migration::run_startup_migrations();
     github::init_releases_cache();
+    validate_window_state();
 
     let dispatch_sender = utils::log_bus::init_log_channel();
     let dispatch = tauri_plugin_log::fern::Dispatch::new().chain(

--- a/src-tauri/src/setup.rs
+++ b/src-tauri/src/setup.rs
@@ -26,7 +26,10 @@ pub fn on_setup(app: &tauri::App) -> std::result::Result<(), Box<dyn std::error:
     }
 
     if let Some(main_window) = app.get_webview_window("main") {
-        let _ = main_window.set_min_size(Some(tauri::LogicalSize::new(1000.0, 680.0)));
+        let _ = main_window.set_min_size(Some(tauri::LogicalSize::new(
+            crate::MIN_WINDOW_WIDTH as f64,
+            crate::MIN_WINDOW_HEIGHT as f64,
+        )));
     }
 
     let state: tauri::State<'_, AppState> = app.state();

--- a/src-tauri/src/setup.rs
+++ b/src-tauri/src/setup.rs
@@ -25,6 +25,10 @@ pub fn on_setup(app: &tauri::App) -> std::result::Result<(), Box<dyn std::error:
         let _ = main_window.set_decorations(false);
     }
 
+    if let Some(main_window) = app.get_webview_window("main") {
+        let _ = main_window.set_min_size(Some(tauri::LogicalSize::new(1000.0, 680.0)));
+    }
+
     let state: tauri::State<'_, AppState> = app.state();
     state.process_manager.start_monitor();
 


### PR DESCRIPTION
## Summary by Sourcery

Enforce a minimum window size and validate persisted window state before launching the app to prevent restored windows from being smaller than the supported dimensions.

New Features:
- Persist and enforce minimum width and height constraints for the main window on restore.

Bug Fixes:
- Prevent the main window from restoring to a size smaller than the minimum supported dimensions by correcting invalid saved window state.

Enhancements:
- Initialize window state validation during startup to ensure existing persisted configurations remain compatible with new size constraints.