### PR TITLE
feat: add component uninstall support

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -302,6 +302,7 @@ define_save_config_command!(
 enum ComponentCommandAction {
     Install,
     Reinstall,
+    Uninstall,
 }
 
 async fn run_component_command(
@@ -320,6 +321,11 @@ async fn run_component_command(
         }
         ComponentCommandAction::Reinstall => {
             component::reinstall_component(&client, id, Some(app_handle)).await
+        }
+        ComponentCommandAction::Uninstall => {
+            tokio::task::spawn_blocking(move || component::uninstall_component(id))
+                .await
+                .map_err(|e| AppError::process(format!("Uninstall task panicked: {}", e)))?
         }
     }
 }
@@ -350,6 +356,21 @@ pub async fn reinstall_component(
         &state,
         &component_id,
         ComponentCommandAction::Reinstall,
+    )
+    .await
+}
+
+#[tauri::command]
+pub async fn uninstall_component(
+    app_handle: AppHandle,
+    state: State<'_, AppState>,
+    component_id: String,
+) -> Result<String> {
+    run_component_command(
+        &app_handle,
+        &state,
+        &component_id,
+        ComponentCommandAction::Uninstall,
     )
     .await
 }

--- a/src-tauri/src/component/mod.rs
+++ b/src-tauri/src/component/mod.rs
@@ -63,6 +63,23 @@ pub async fn install_component(
     result
 }
 
+/// Uninstall a component by id, dispatching to the appropriate sub-module.
+pub fn uninstall_component(id: ComponentId) -> Result<String> {
+    log::info!("Uninstalling component {:?}", id);
+    let result = match id {
+        ComponentId::Python => python::uninstall_component(),
+        ComponentId::Nodejs => nodejs::uninstall_nodejs(),
+        ComponentId::UV => uv::uninstall_uv(),
+    };
+
+    match &result {
+        Ok(msg) => log::info!("Component {:?} uninstalled: {}", id, msg),
+        Err(e) => log::error!("Failed to uninstall component {:?}: {}", id, e),
+    }
+
+    result
+}
+
 /// Reinstall a component by id, dispatching to the appropriate sub-module.
 pub async fn reinstall_component(
     client: &Client,

--- a/src-tauri/src/component/nodejs.rs
+++ b/src-tauri/src/component/nodejs.rs
@@ -125,6 +125,18 @@ pub async fn install_nodejs(client: &Client, app_handle: Option<&AppHandle>) -> 
     Ok(format!("已安装 Node.js (LTS): {}", version))
 }
 
+/// Uninstall Node.js LTS.
+pub fn uninstall_nodejs() -> Result<String> {
+    let dir = get_component_dir("nodejs");
+    if dir.exists() {
+        std::fs::remove_dir_all(&dir)
+            .map_err(|e| AppError::io(format!("Failed to remove Node.js: {}", e)))?;
+        Ok("已卸载 Node.js (LTS)".to_string())
+    } else {
+        Ok("Node.js (LTS) 组件未安装".to_string())
+    }
+}
+
 /// Reinstall Node.js LTS (always removes existing and re-downloads).
 pub async fn reinstall_nodejs(client: &Client, app_handle: Option<&AppHandle>) -> Result<String> {
     let version = do_install_nodejs(client, app_handle).await?;

--- a/src-tauri/src/component/python.rs
+++ b/src-tauri/src/component/python.rs
@@ -70,6 +70,32 @@ pub(super) async fn install_component(
     }
 }
 
+/// Uninstall unified Python component (3.10 + 3.12).
+pub(super) fn uninstall_component() -> Result<String> {
+    let py310_dir = get_python_runtime_dir(RUNTIME_PY310);
+    let py312_dir = get_python_runtime_dir(RUNTIME_PY312);
+
+    let mut removed = Vec::new();
+    for dir in [&py310_dir, &py312_dir] {
+        if dir.exists() {
+            std::fs::remove_dir_all(dir)
+                .map_err(|e| AppError::io(format!("Failed to remove Python runtime: {}", e)))?;
+            removed.push(
+                dir.file_name()
+                    .unwrap_or_default()
+                    .to_string_lossy()
+                    .to_string(),
+            );
+        }
+    }
+
+    if removed.is_empty() {
+        Ok("Python 组件未安装".to_string())
+    } else {
+        Ok(format!("已卸载 Python: {}", removed.join(", ")))
+    }
+}
+
 /// Reinstall unified Python component (3.10 + 3.12).
 pub(super) async fn reinstall_component(
     client: &Client,

--- a/src-tauri/src/component/uv.rs
+++ b/src-tauri/src/component/uv.rs
@@ -100,6 +100,18 @@ pub async fn install_uv(client: &Client, app_handle: Option<&AppHandle>) -> Resu
     Ok(format!("已安装 uv: {}", version))
 }
 
+/// Uninstall uv.
+pub fn uninstall_uv() -> Result<String> {
+    let dir = get_component_dir("uv");
+    if dir.exists() {
+        std::fs::remove_dir_all(&dir)
+            .map_err(|e| AppError::io(format!("Failed to remove uv: {}", e)))?;
+        Ok("已卸载 uv".to_string())
+    } else {
+        Ok("uv 组件未安装".to_string())
+    }
+}
+
 pub async fn reinstall_uv(client: &Client, app_handle: Option<&AppHandle>) -> Result<String> {
     let version = do_install_uv(client, app_handle).await?;
     Ok(format!("已重新安装 uv: {}", version))

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -178,6 +178,7 @@ pub fn run() {
             // Components
             commands::install_component,
             commands::reinstall_component,
+            commands::uninstall_component,
             // GitHub
             commands::fetch_releases,
             commands::fetch_launcher_release_notes,

--- a/src/api.ts
+++ b/src/api.ts
@@ -57,6 +57,8 @@ export const api = {
   installComponent: (componentId: string) => invoke<string>('install_component', { componentId }),
   reinstallComponent: (componentId: string) =>
     invoke<string>('reinstall_component', { componentId }),
+  uninstallComponent: (componentId: string) =>
+    invoke<string>('uninstall_component', { componentId }),
 
   // ========================================
   // GitHub

--- a/src/constants/operationKeys.ts
+++ b/src/constants/operationKeys.ts
@@ -7,6 +7,7 @@ export const OPERATION_KEYS = {
   uninstallVersion: (version: string) => `uninstall:${version}`,
   installComponent: (componentId: string) => `install-component:${componentId}`,
   reinstallComponent: (componentId: string) => `reinstall-component:${componentId}`,
+  uninstallComponent: (componentId: string) => `uninstall-component:${componentId}`,
   fetchReleases: 'fetch-releases',
 
   backupCreate: 'backup:create',

--- a/src/pages/Versions.tsx
+++ b/src/pages/Versions.tsx
@@ -200,9 +200,11 @@ export default function Versions() {
             renderItem={(comp) => {
               const installKey = OPERATION_KEYS.installComponent(comp.id);
               const reinstallKey = OPERATION_KEYS.reinstallComponent(comp.id);
+              const uninstallKey = OPERATION_KEYS.uninstallComponent(comp.id);
               const isInstalling = operations[installKey] || false;
               const isReinstalling = operations[reinstallKey] || false;
-              const isComponentOperating = isInstalling || isReinstalling;
+              const isUninstalling = operations[uninstallKey] || false;
+              const isComponentOperating = isInstalling || isReinstalling || isUninstalling;
               // During reinstall, backend may transiently report installed=false while files are replaced.
               // Keep UI in "installed/reinstall" branch to avoid button type flipping on route switches.
               const showAsInstalled = comp.installed || isReinstalling;

--- a/src/pages/Versions.tsx
+++ b/src/pages/Versions.tsx
@@ -34,6 +34,11 @@ export default function Versions() {
   const [detailOpen, setDetailOpen] = useState(false);
   const [uninstallOpen, setUninstallOpen] = useState(false);
   const [versionToUninstall, setVersionToUninstall] = useState<InstalledVersion | null>(null);
+  const [componentUninstallOpen, setComponentUninstallOpen] = useState(false);
+  const [componentToUninstall, setComponentToUninstall] = useState<{
+    id: string;
+    display_name: string;
+  } | null>(null);
   const [releases, setReleases] = useState<GitHubRelease[]>([]);
   const releasesLoading = operations[OPERATION_KEYS.fetchReleases] || false;
 
@@ -145,6 +150,23 @@ export default function Versions() {
     [runOperation, clearDownloadProgress]
   );
 
+  const handleComponentUninstall = useCallback(async () => {
+    if (!componentToUninstall) return;
+    const key = OPERATION_KEYS.uninstallComponent(componentToUninstall.id);
+    await runOperation({
+      key,
+      task: () => api.uninstallComponent(componentToUninstall.id),
+      onSuccess: (result) => {
+        message.success(result);
+      },
+      onError: (error) => {
+        handleApiError(error);
+      },
+    });
+    setComponentUninstallOpen(false);
+    setComponentToUninstall(null);
+  }, [componentToUninstall, runOperation]);
+
   const isInstalled = (tagName: string) => versions.some((v) => v.version === tagName);
   const availableReleases = releases.filter((r) => !isInstalled(r.tag_name));
   const getInstalledRelease = (version: string) => releases.find((r) => r.tag_name === version);
@@ -209,6 +231,21 @@ export default function Versions() {
                               loading={isComponentOperating}
                               disabled={isComponentOperating}
                               onClick={() => runComponentInstallAction(comp.id, 'reinstall')}
+                            />
+                          </Tooltip>,
+                          <Tooltip title="卸载" key="uninstall">
+                            <Button
+                              type="text"
+                              danger
+                              icon={<DeleteOutlined />}
+                              disabled={isComponentOperating}
+                              onClick={() => {
+                                setComponentToUninstall({
+                                  id: comp.id,
+                                  display_name: comp.display_name,
+                                });
+                                setComponentUninstallOpen(true);
+                              }}
                             />
                           </Tooltip>,
                         ].filter(Boolean)
@@ -435,6 +472,31 @@ export default function Versions() {
         onCancel={() => {
           setUninstallOpen(false);
           setVersionToUninstall(null);
+        }}
+      />
+
+      {/* Component Uninstall Modal */}
+      <ConfirmModal
+        open={componentUninstallOpen}
+        title="确认卸载组件"
+        danger
+        content={
+          <>
+            <p>确定卸载此组件？卸载后需重新下载才能使用。</p>
+            {componentToUninstall && (
+              <Text type="secondary">组件: {componentToUninstall.display_name}</Text>
+            )}
+          </>
+        }
+        loading={
+          componentToUninstall
+            ? operations[OPERATION_KEYS.uninstallComponent(componentToUninstall.id)] || false
+            : false
+        }
+        onConfirm={handleComponentUninstall}
+        onCancel={() => {
+          setComponentUninstallOpen(false);
+          setComponentToUninstall(null);
         }}
       />
     </>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -150,15 +150,7 @@ export interface DownloadProgress {
 }
 
 export type DeployStep =
-  | 'backup'
-  | 'extract'
-  | 'venv'
-  | 'deps'
-  | 'webui'
-  | 'restore'
-  | 'start'
-  | 'done'
-  | 'error';
+  'backup' | 'extract' | 'venv' | 'deps' | 'webui' | 'restore' | 'start' | 'done' | 'error';
 
 export interface DeployProgress {
   instance_id: string;
@@ -170,10 +162,7 @@ export interface DeployProgress {
 export type DeployType = 'start' | 'upgrade' | 'downgrade' | null;
 
 export type RepairPreserveScope =
-  | 'data_directory'
-  | 'config_and_data_files'
-  | 'core_config_and_data_files'
-  | 'database_only';
+  'data_directory' | 'config_and_data_files' | 'core_config_and_data_files' | 'database_only';
 
 export interface DeployState {
   instanceName: string;


### PR DESCRIPTION
Add trash icon uninstall button in component management card, with confirmation modal. Backend removes the component directory for Python runtimes, Node.js, and uv.

## Summary by Sourcery

Add support for uninstalling runtime components from the UI and backend.

New Features:
- Add uninstall button with confirmation modal for components in the Versions page.
- Expose a new uninstall_component Tauri command and wire it through the frontend API and operation keys.

Enhancements:
- Implement component-specific uninstall handlers for Python, Node.js, and uv that remove their runtime directories and log outcomes.
- Slightly tidy TypeScript union type formatting in shared types.