### PR TITLE
refactor: replace api.soulter.top releases endpoint with GitHub API via gh-proxy

### DIFF
--- a/src-tauri/src/network_config.rs
+++ b/src-tauri/src/network_config.rs
@@ -16,7 +16,6 @@ pub(crate) const MAINLAND_PYTHON_BUILD_STANDALONE_BASE: &str =
     "https://mirrors.ustc.edu.cn/github-release/astral-sh/python-build-standalone/LatestRelease/";
 pub(crate) const MAINLAND_UV_RELEASE_BASE: &str =
     "https://mirrors.ustc.edu.cn/github-release/astral-sh/uv/LatestRelease/";
-pub(crate) const MAINLAND_ASTRBOT_RELEASES_API: &str = "https://api.soulter.top/releases";
 pub(crate) const MAINLAND_ASTRBOT_DOWNLOAD_PROXY: &str = "https://gh-proxy.org/";
 
 pub(crate) fn mainland_acceleration(config: &AppConfig) -> bool {
@@ -73,7 +72,7 @@ pub(crate) fn npm_registry(config: &AppConfig) -> Option<String> {
 
 pub(crate) fn astrbot_releases_api_url(config: &AppConfig) -> String {
     if mainland_acceleration(config) {
-        MAINLAND_ASTRBOT_RELEASES_API.to_string()
+        build_api_url(MAINLAND_ASTRBOT_DOWNLOAD_PROXY)
     } else {
         build_api_url(&config.github_proxy)
     }


### PR DESCRIPTION
Replace the custom `api.soulter.top/releases` endpoint with the official GitHub Releases API, proxied through `gh-proxy.org` when mainland acceleration is enabled. This removes the dependency on the soulter.top middleware and keeps release fetching consistent with other mainland acceleration proxy usage.

## Summary by Sourcery

Enhancements:
- Remove the custom api.soulter.top AstrBot releases endpoint in favor of constructing the releases URL via the GitHub download proxy when mainland acceleration is enabled.