### PR TITLE
fix: correct deb filename format in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,10 +65,10 @@ jobs:
             const winX64 = `AstrBot.Launcher_${version}_x64-setup.exe`;
             const winArm64 = `AstrBot.Launcher_${version}_arm64-setup.exe`;
             const linuxX64Rpm = `AstrBot.Launcher-${version}-1.x86_64.rpm`;
-            const linuxX64Deb = `astrbot-launcher_${version}_amd64.deb`;
+            const linuxX64Deb = `AstrBot.Launcher_${version}_amd64.deb`;
             const linuxX64AppImage = `AstrBot.Launcher_${version}_amd64.AppImage`;
             const linuxArm64Rpm = `AstrBot.Launcher-${version}-1.aarch64.rpm`;
-            const linuxArm64Deb = `astrbot-launcher_${version}_arm64.deb`;
+            const linuxArm64Deb = `AstrBot.Launcher_${version}_arm64.deb`;
             const linuxArm64AppImage = `AstrBot.Launcher_${version}_aarch64.AppImage`;
             const macX64 = `AstrBot.Launcher_${version}_x64.dmg`;
             const macArm64 = `AstrBot.Launcher_${version}_aarch64.dmg`;


### PR DESCRIPTION
The Tauri bundler generates deb files with dot-separated format (AstrBot.Launcher_x.x.x_amd64.deb) rather than kebab-case.

## Summary by Sourcery

Bug Fixes:
- Fix incorrect Debian package filename patterns for x64 and arm64 artifacts in the release workflow so uploads reference the correct files.