### PR TITLE
feat: allow customizing the data directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@ant-design/icons": "^6.3.2",
     "@tauri-apps/api": "^2.11.1",
     "@tauri-apps/plugin-autostart": "~2.5.1",
+    "@tauri-apps/plugin-dialog": "^2.7.2",
     "@tauri-apps/plugin-log": "~2.9.0",
     "@tauri-apps/plugin-opener": "^2.5.4",
     "@tauri-apps/plugin-process": "~2.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@tauri-apps/plugin-autostart':
         specifier: ~2.5.1
         version: 2.5.1
+      '@tauri-apps/plugin-dialog':
+        specifier: ^2.7.2
+        version: 2.7.2
       '@tauri-apps/plugin-log':
         specifier: ~2.9.0
         version: 2.9.0
@@ -959,6 +962,9 @@ packages:
 
   '@tauri-apps/plugin-autostart@2.5.1':
     resolution: {integrity: sha512-zS/xx7yzveCcotkA+8TqkI2lysmG2wvQXv2HGAVExITmnFfHAdj1arGsbbfs3o6EktRHf6l34pJxc3YGG2mg7w==}
+
+  '@tauri-apps/plugin-dialog@2.7.2':
+    resolution: {integrity: sha512-pX0IGm1I3I6wc+zeKYcq1GSqogK6okCNX5fOdaNU5ab1AjGS6l1E5wFNjEb7meg7ZFSp0JUs+0jQGQNyOvLrsg==}
 
   '@tauri-apps/plugin-log@2.9.0':
     resolution: {integrity: sha512-Ql8okrnsguk0eDq1GvRfttFV5KaeW/7vcao6bdbkXCRJ1+2sWE15ZJvJVEKVANrOKy1mRngqC3IFIAP+wP5qSw==}
@@ -3164,6 +3170,10 @@ snapshots:
       '@tauri-apps/cli-win32-x64-msvc': 2.11.4
 
   '@tauri-apps/plugin-autostart@2.5.1':
+    dependencies:
+      '@tauri-apps/api': 2.11.1
+
+  '@tauri-apps/plugin-dialog@2.7.2':
     dependencies:
       '@tauri-apps/api': 2.11.1
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -106,6 +106,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-autostart",
+ "tauri-plugin-dialog",
  "tauri-plugin-log",
  "tauri-plugin-opener",
  "tauri-plugin-process",
@@ -3489,6 +3490,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4387,6 +4412,48 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "tauri-plugin-dialog"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2d3c1dbe38037e7f590cdf2492594d5ceebe031e7bc7e827509b22a999d2940"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ecc274121aca0c036a2b42d1cbe83d368d348f54e0bb8a735c2b1548e8f371"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "log",
+ "objc2-foundation",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "toml 1.1.2+spec-1.1.0",
+ "url",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -20,6 +20,7 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 tauri = { version = "2", features = ["tray-icon"] }
 tauri-plugin-opener = "2"
+tauri-plugin-dialog = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.9.11"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -6,6 +6,7 @@
   "permissions": [
     "core:default",
     "opener:default",
+    "dialog:allow-open",
     "core:window:allow-minimize",
     "core:window:allow-toggle-maximize",
     "core:window:allow-close",

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -22,7 +22,10 @@ use crate::process::ProcessManager;
 use crate::utils::index_url::normalize_default_index;
 use crate::utils::lock_check::{collect_files_for_lock_check, ensure_target_not_locked};
 use crate::utils::net::{build_http_client_with_proxy, check_url};
-use crate::utils::paths::get_instance_core_dir;
+use crate::utils::paths::{
+    default_data_dir, ensure_data_dirs, get_data_dir, get_instance_core_dir, set_data_dir_override,
+    validate_data_dir,
+};
 use crate::utils::proxy::{
     build_single_url_proxy_settings, ProxyFields, ProxySource, DEFAULT_NO_PROXY_VALUE,
 };
@@ -104,6 +107,7 @@ pub(crate) fn build_app_snapshot_with(
         backups,
         components: component::build_components_snapshot(),
         config: config_for_snapshot,
+        data_dir: get_data_dir().display().to_string(),
     })
 }
 
@@ -132,6 +136,7 @@ pub struct AppSnapshot {
     pub backups: Vec<BackupInfo>,
     pub components: ComponentsSnapshot,
     pub config: AppConfig,
+    pub data_dir: String,
 }
 
 // === Config ===
@@ -296,6 +301,67 @@ define_save_config_command!(
     theme_preference: ThemePreference,
     theme_preference
 );
+
+// === Data Directory ===
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct DataDirChangeResult {
+    pub old_dir: String,
+    pub new_dir: String,
+}
+
+/// Compare data directory paths case-insensitively on case-insensitive
+/// filesystems by canonicalizing paths that already exist.
+fn comparable_data_dir(dir: &std::path::Path) -> std::path::PathBuf {
+    std::fs::canonicalize(dir).unwrap_or_else(|_| dir.to_path_buf())
+}
+
+#[tauri::command]
+pub async fn set_data_dir(
+    new_dir: String,
+    state: State<'_, AppState>,
+) -> Result<DataDirChangeResult> {
+    if !state.process_manager.get_active_ids().is_empty() {
+        return Err(AppError::other("请先停止所有运行中的实例，再更改数据目录"));
+    }
+
+    let old_dir = get_data_dir();
+    let trimmed = new_dir.trim();
+
+    let new_path = if trimmed.is_empty() {
+        // Reset to the default location.
+        default_data_dir()
+    } else {
+        let path = std::path::PathBuf::from(trimmed);
+        validate_data_dir(&path)?;
+        path
+    };
+
+    if comparable_data_dir(&new_path) == comparable_data_dir(&old_dir) {
+        return Err(AppError::other("新数据目录与当前数据目录相同"));
+    }
+
+    set_data_dir_override(if trimmed.is_empty() {
+        None
+    } else {
+        Some(&new_path)
+    })?;
+    ensure_data_dirs()?;
+
+    Ok(DataDirChangeResult {
+        old_dir: old_dir.display().to_string(),
+        new_dir: new_path.display().to_string(),
+    })
+}
+
+#[tauri::command]
+pub async fn open_folder(path: String) -> Result<()> {
+    let dir = std::path::PathBuf::from(path);
+    if !dir.is_dir() {
+        return Err(AppError::other("目标文件夹不存在"));
+    }
+    open_path(&dir, None::<&str>).map_err(|e| AppError::io(e.to_string()))
+}
 
 // === Components ===
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -33,10 +33,8 @@ pub(crate) const MIN_WINDOW_WIDTH: u32 = 1000;
 pub(crate) const MIN_WINDOW_HEIGHT: u32 = 680;
 
 fn validate_window_state() {
-    let state_path = match dirs::config_dir() {
-        Some(d) => d
-            .join("com.github.raven95676.astrbot-launcher")
-            .join(".window-state.json"),
+    let state_path = match utils::paths::launcher_config_dir() {
+        Some(d) => d.join(".window-state.json"),
         None => return,
     };
 
@@ -126,6 +124,7 @@ pub fn run() {
                 .build(),
         )
         .plugin(tauri_plugin_opener::init())
+        .plugin(tauri_plugin_dialog::init())
         .manage({
             let startup_client = (|| {
                 let config = load_config()?;
@@ -175,6 +174,9 @@ pub fn run() {
             commands::save_theme_preference,
             commands::save_mainland_acceleration,
             commands::is_macos,
+            // Data Directory
+            commands::set_data_dir,
+            commands::open_folder,
             // Components
             commands::install_component,
             commands::reinstall_component,

--- a/src-tauri/src/utils/paths.rs
+++ b/src-tauri/src/utils/paths.rs
@@ -4,6 +4,8 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::RwLock;
 
+use once_cell::sync::Lazy;
+
 use crate::error::{AppError, Result};
 use crate::utils::sync::{read_lock_recover, write_lock_recover};
 
@@ -15,8 +17,11 @@ const LAUNCHER_CONFIG_SUBDIR: &str = "com.github.raven95676.astrbot-launcher";
 /// File storing the user-configured data directory override.
 const DATA_DIR_OVERRIDE_FILE: &str = ".data-dir.json";
 
-/// Cached resolved data directory. `None` means "not resolved yet".
-static DATA_DIR_CACHE: RwLock<Option<PathBuf>> = RwLock::new(None);
+/// Resolved data directory. Initialized from the override file (if any) or the
+/// default location on first use, and re-resolved whenever the override
+/// changes.
+static DATA_DIR_CACHE: Lazy<RwLock<PathBuf>> =
+    Lazy::new(|| RwLock::new(load_data_dir_override().unwrap_or_else(default_data_dir)));
 
 /// Get the launcher config directory (`<config_dir>/com.github.raven95676.astrbot-launcher`).
 pub(crate) fn launcher_config_dir() -> Option<PathBuf> {
@@ -85,25 +90,12 @@ fn load_data_dir_override() -> Option<PathBuf> {
 /// Uses the user-configured override if present, otherwise falls back to
 /// the default (~/.astrbot_launcher).
 pub(crate) fn get_data_dir() -> PathBuf {
-    let cached = read_lock_recover(&DATA_DIR_CACHE, "DATA_DIR_CACHE").clone();
-    if let Some(dir) = cached {
-        return dir;
-    }
-
-    let dir = load_data_dir_override().unwrap_or_else(default_data_dir);
-    let mut guard = write_lock_recover(&DATA_DIR_CACHE, "DATA_DIR_CACHE");
-    if guard.is_none() {
-        *guard = Some(dir.clone());
-    }
-    dir
+    read_lock_recover(&DATA_DIR_CACHE, "DATA_DIR_CACHE").clone()
 }
 
-/// Persist a new data directory override, or remove the override to fall back
-/// to the default when `new_dir` is `None`.
-///
-/// Takes effect for all path helpers immediately and for the rest of the
-/// application after a restart. Does not migrate any data.
-pub(crate) fn set_data_dir_override(new_dir: Option<&Path>) -> Result<()> {
+/// Persist a data directory override to disk, or remove the override file to
+/// fall back to the default when `new_dir` is `None`.
+fn persist_data_dir_override(new_dir: Option<&Path>) -> Result<()> {
     let config_dir = launcher_config_dir()
         .ok_or_else(|| AppError::other("无法确定应用配置目录，请检查操作系统环境后重试"))?;
     let override_path = config_dir.join(DATA_DIR_OVERRIDE_FILE);
@@ -113,18 +105,31 @@ pub(crate) fn set_data_dir_override(new_dir: Option<&Path>) -> Result<()> {
         fs::create_dir_all(&config_dir).map_err(|e| AppError::io(e.to_string()))?;
         let payload = serde_json::json!({ "data_dir": dir.to_string_lossy() });
         fs::write(&override_path, payload.to_string()).map_err(|e| AppError::io(e.to_string()))?;
-
-        let mut guard = write_lock_recover(&DATA_DIR_CACHE, "DATA_DIR_CACHE");
-        *guard = Some(dir.to_path_buf());
     } else {
         match fs::remove_file(&override_path) {
             Ok(()) => {}
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
             Err(e) => return Err(AppError::io(e.to_string())),
         }
-        let mut guard = write_lock_recover(&DATA_DIR_CACHE, "DATA_DIR_CACHE");
-        *guard = Some(default_data_dir());
     }
+    Ok(())
+}
+
+/// Re-resolve the cached data directory from the override file.
+fn recompute_data_dir_cache() {
+    let dir = load_data_dir_override().unwrap_or_else(default_data_dir);
+    let mut guard = write_lock_recover(&DATA_DIR_CACHE, "DATA_DIR_CACHE");
+    *guard = dir;
+}
+
+/// Persist a new data directory override, or remove the override to fall back
+/// to the default when `new_dir` is `None`.
+///
+/// Takes effect for all path helpers immediately and for the rest of the
+/// application after a restart. Does not migrate any data.
+pub(crate) fn set_data_dir_override(new_dir: Option<&Path>) -> Result<()> {
+    persist_data_dir_override(new_dir)?;
+    recompute_data_dir_cache();
     Ok(())
 }
 

--- a/src-tauri/src/utils/paths.rs
+++ b/src-tauri/src/utils/paths.rs
@@ -2,14 +2,130 @@
 
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::RwLock;
 
 use crate::error::{AppError, Result};
+use crate::utils::sync::{read_lock_recover, write_lock_recover};
 
-/// Get the root data directory for the application (~/.astrbot_launcher).
+/// Directory (under the OS config directory) used for launcher-internal files
+/// that must live outside the user-selectable data directory, such as the
+/// data directory override itself.
+const LAUNCHER_CONFIG_SUBDIR: &str = "com.github.raven95676.astrbot-launcher";
+
+/// File storing the user-configured data directory override.
+const DATA_DIR_OVERRIDE_FILE: &str = ".data-dir.json";
+
+/// Cached resolved data directory. `None` means "not resolved yet".
+static DATA_DIR_CACHE: RwLock<Option<PathBuf>> = RwLock::new(None);
+
+/// Get the launcher config directory (`<config_dir>/com.github.raven95676.astrbot-launcher`).
+pub(crate) fn launcher_config_dir() -> Option<PathBuf> {
+    dirs::config_dir().map(|dir| dir.join(LAUNCHER_CONFIG_SUBDIR))
+}
+
+fn data_dir_override_path() -> Option<PathBuf> {
+    launcher_config_dir().map(|dir| dir.join(DATA_DIR_OVERRIDE_FILE))
+}
+
+/// The default data directory (~/.astrbot_launcher).
 #[allow(clippy::expect_used)]
-pub(crate) fn get_data_dir() -> PathBuf {
+pub(crate) fn default_data_dir() -> PathBuf {
     let home = dirs::home_dir().expect("Cannot find home directory");
     home.join(".astrbot_launcher")
+}
+
+/// Validate a user-provided data directory path.
+pub(crate) fn validate_data_dir(dir: &Path) -> Result<()> {
+    if dir.as_os_str().is_empty() {
+        return Err(AppError::other("数据目录不能为空"));
+    }
+    if !dir.is_absolute() {
+        return Err(AppError::other("数据目录必须是绝对路径"));
+    }
+    if dir.is_file() {
+        return Err(AppError::other(
+            "目标路径已存在且是一个文件，请选择一个文件夹",
+        ));
+    }
+    Ok(())
+}
+
+#[derive(serde::Deserialize)]
+struct DataDirOverrideFile {
+    data_dir: String,
+}
+
+/// Load the data directory override from disk, if any.
+fn load_data_dir_override() -> Option<PathBuf> {
+    let path = data_dir_override_path()?;
+    let content = fs::read_to_string(&path).ok()?;
+    let parsed: DataDirOverrideFile = match serde_json::from_str(&content) {
+        Ok(value) => value,
+        Err(error) => {
+            log::warn!(
+                "Data dir override file is corrupted, ignoring it: {}",
+                error
+            );
+            return None;
+        }
+    };
+    let dir = PathBuf::from(parsed.data_dir.trim());
+    if validate_data_dir(&dir).is_err() {
+        log::warn!(
+            "Stored data dir override is invalid, ignoring it: {}",
+            dir.display()
+        );
+        return None;
+    }
+    Some(dir)
+}
+
+/// Get the root data directory for the application.
+///
+/// Uses the user-configured override if present, otherwise falls back to
+/// the default (~/.astrbot_launcher).
+pub(crate) fn get_data_dir() -> PathBuf {
+    let cached = read_lock_recover(&DATA_DIR_CACHE, "DATA_DIR_CACHE").clone();
+    if let Some(dir) = cached {
+        return dir;
+    }
+
+    let dir = load_data_dir_override().unwrap_or_else(default_data_dir);
+    let mut guard = write_lock_recover(&DATA_DIR_CACHE, "DATA_DIR_CACHE");
+    if guard.is_none() {
+        *guard = Some(dir.clone());
+    }
+    dir
+}
+
+/// Persist a new data directory override, or remove the override to fall back
+/// to the default when `new_dir` is `None`.
+///
+/// Takes effect for all path helpers immediately and for the rest of the
+/// application after a restart. Does not migrate any data.
+pub(crate) fn set_data_dir_override(new_dir: Option<&Path>) -> Result<()> {
+    let config_dir = launcher_config_dir()
+        .ok_or_else(|| AppError::other("无法确定应用配置目录，请检查操作系统环境后重试"))?;
+    let override_path = config_dir.join(DATA_DIR_OVERRIDE_FILE);
+
+    if let Some(dir) = new_dir {
+        validate_data_dir(dir)?;
+        fs::create_dir_all(&config_dir).map_err(|e| AppError::io(e.to_string()))?;
+        let payload = serde_json::json!({ "data_dir": dir.to_string_lossy() });
+        fs::write(&override_path, payload.to_string()).map_err(|e| AppError::io(e.to_string()))?;
+
+        let mut guard = write_lock_recover(&DATA_DIR_CACHE, "DATA_DIR_CACHE");
+        *guard = Some(dir.to_path_buf());
+    } else {
+        match fs::remove_file(&override_path) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => return Err(AppError::io(e.to_string())),
+        }
+        let mut guard = write_lock_recover(&DATA_DIR_CACHE, "DATA_DIR_CACHE");
+        *guard = Some(default_data_dir());
+    }
+    Ok(())
 }
 
 /// Get the path to the unified application data database.

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,6 +1,6 @@
 import { invoke } from '@tauri-apps/api/core';
 import type { GitHubRelease, AppSnapshot, ThemePreference } from './types';
-import type { RepairPreserveScope } from './types';
+import type { DataDirChangeResult, RepairPreserveScope } from './types';
 
 type LockCheckRequest =
   | {
@@ -50,6 +50,12 @@ export const api = {
     invoke<void>('save_lock_check_extension_whitelist', { lockCheckExtensionWhitelist }),
   saveThemePreference: (themePreference: ThemePreference) =>
     invoke<void>('save_theme_preference', { themePreference }),
+
+  // ========================================
+  // Data Directory
+  // ========================================
+  setDataDir: (newDir: string) => invoke<DataDirChangeResult>('set_data_dir', { newDir }),
+  openFolder: (path: string) => invoke<void>('open_folder', { path }),
 
   // ========================================
   // Components

--- a/src/components/DataDirMigrationModal.tsx
+++ b/src/components/DataDirMigrationModal.tsx
@@ -1,0 +1,79 @@
+import { useEffect, useState } from 'react';
+import { Alert, Button, Modal, Space, Typography } from 'antd';
+import { exit } from '@tauri-apps/plugin-process';
+import { api } from '../api';
+import { handleApiError } from '../utils';
+import type { DataDirChangeResult } from '../types';
+
+const { Text } = Typography;
+
+/** Seconds the user must wait before confirming the data directory change. */
+const CONFIRM_WAIT_SECONDS = 3;
+
+interface DataDirMigrationModalProps {
+  change: DataDirChangeResult;
+}
+
+export function DataDirMigrationModal({ change }: DataDirMigrationModalProps) {
+  const [remaining, setRemaining] = useState(CONFIRM_WAIT_SECONDS);
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setRemaining((prev) => Math.max(0, prev - 1));
+    }, 1000);
+    return () => clearInterval(timer);
+  }, []);
+
+  const ready = remaining === 0;
+
+  const handleOpenFolder = (path: string) => {
+    api.openFolder(path).catch(handleApiError);
+  };
+
+  return (
+    <Modal
+      open
+      title="数据目录已更改"
+      closable={false}
+      maskClosable={false}
+      keyboard={false}
+      footer={[
+        <Button key="confirm" type="primary" disabled={!ready} onClick={() => void exit(0)}>
+          {ready ? '我已知晓，退出应用' : `我已知晓（${remaining} 秒后可用）`}
+        </Button>,
+      ]}
+    >
+      <Alert
+        type="warning"
+        showIcon
+        message="新数据目录将在下次启动时生效，请先手动迁移数据"
+        description="更改数据目录不会自动迁移现有数据。请按以下步骤操作，以免实例、版本等数据无法显示："
+        style={{ marginBottom: 16 }}
+      />
+      <Space direction="vertical" size="small" style={{ width: '100%' }}>
+        <Text>1. 点击下方「我已知晓」按钮，应用将自动退出；</Text>
+        <Text>
+          2. 将旧数据目录中的全部内容（包括 data.redb、instances、versions、 components、backups
+          等）移动到新数据目录；
+        </Text>
+        <Text>3. 重新启动 AstrBot Launcher。</Text>
+      </Space>
+      <Space direction="vertical" size="small" style={{ width: '100%', marginTop: 16 }}>
+        <Space wrap>
+          <Text strong>旧数据目录：</Text>
+          <Text code>{change.old_dir}</Text>
+          <Button size="small" onClick={() => handleOpenFolder(change.old_dir)}>
+            打开
+          </Button>
+        </Space>
+        <Space wrap>
+          <Text strong>新数据目录：</Text>
+          <Text code>{change.new_dir}</Text>
+          <Button size="small" onClick={() => handleOpenFolder(change.new_dir)}>
+            打开
+          </Button>
+        </Space>
+      </Space>
+    </Modal>
+  );
+}

--- a/src/components/DataDirMigrationModal.tsx
+++ b/src/components/DataDirMigrationModal.tsx
@@ -12,10 +12,12 @@ const CONFIRM_WAIT_SECONDS = 3;
 
 interface DataDirMigrationModalProps {
   change: DataDirChangeResult;
+  onExitFailed: () => void;
 }
 
-export function DataDirMigrationModal({ change }: DataDirMigrationModalProps) {
+export function DataDirMigrationModal({ change, onExitFailed }: DataDirMigrationModalProps) {
   const [remaining, setRemaining] = useState(CONFIRM_WAIT_SECONDS);
+  const [exiting, setExiting] = useState(false);
 
   useEffect(() => {
     const timer = setInterval(() => {
@@ -30,6 +32,16 @@ export function DataDirMigrationModal({ change }: DataDirMigrationModalProps) {
     api.openFolder(path).catch(handleApiError);
   };
 
+  const handleExit = async () => {
+    setExiting(true);
+    try {
+      await exit(0);
+    } catch (error) {
+      handleApiError(error, '退出应用失败');
+      onExitFailed();
+    }
+  };
+
   return (
     <Modal
       open
@@ -38,7 +50,13 @@ export function DataDirMigrationModal({ change }: DataDirMigrationModalProps) {
       maskClosable={false}
       keyboard={false}
       footer={[
-        <Button key="confirm" type="primary" disabled={!ready} onClick={() => void exit(0)}>
+        <Button
+          key="confirm"
+          type="primary"
+          disabled={!ready || exiting}
+          loading={exiting}
+          onClick={() => void handleExit()}
+        >
           {ready ? '我已知晓，退出应用' : `我已知晓（${remaining} 秒后可用）`}
         </Button>,
       ]}

--- a/src/components/advanced/DataDirSettingsCard.tsx
+++ b/src/components/advanced/DataDirSettingsCard.tsx
@@ -1,0 +1,57 @@
+import { Button, Card, Form, Input, Space } from 'antd';
+import { open } from '@tauri-apps/plugin-dialog';
+import { api } from '../../api';
+import { message } from '../../antdStatic';
+import { handleApiError } from '../../utils';
+
+interface DataDirSettingsCardProps {
+  dataDir: string | null;
+  saving: boolean;
+  onSetDataDir: (newDir: string) => Promise<void>;
+}
+
+export function DataDirSettingsCard({ dataDir, saving, onSetDataDir }: DataDirSettingsCardProps) {
+  const handleOpenCurrentDir = () => {
+    if (dataDir) {
+      api.openFolder(dataDir).catch(handleApiError);
+    }
+  };
+
+  const handleChangeDir = async () => {
+    if (saving) return;
+    try {
+      const selected = await open({
+        directory: true,
+        multiple: false,
+        title: '选择数据目录',
+        defaultPath: dataDir || undefined,
+      });
+      if (typeof selected !== 'string') return;
+      if (selected === dataDir) {
+        message.info('所选目录与当前数据目录相同');
+        return;
+      }
+      await onSetDataDir(selected);
+    } catch (error) {
+      handleApiError(error);
+    }
+  };
+
+  return (
+    <Card title="数据目录" size="small" style={{ marginBottom: 16 }}>
+      <Form layout="vertical">
+        <Form.Item label="当前数据目录" extra="实例、版本、组件和备份等所有数据都存储在此目录中">
+          <Space.Compact style={{ width: '100%' }}>
+            <Input value={dataDir ?? ''} readOnly />
+            <Button onClick={handleOpenCurrentDir} disabled={!dataDir}>
+              打开
+            </Button>
+            <Button onClick={() => void handleChangeDir()} loading={saving} disabled={saving}>
+              更改
+            </Button>
+          </Space.Compact>
+        </Form.Item>
+      </Form>
+    </Card>
+  );
+}

--- a/src/constants/operationKeys.ts
+++ b/src/constants/operationKeys.ts
@@ -29,6 +29,7 @@ export const OPERATION_KEYS = {
   advancedSaveUseUvForDeps: 'adv:save-use-uv-for-deps',
   advancedSaveLockCheckExtensionWhitelist: 'adv:save-lock-check-extension-whitelist',
   advancedSaveThemePreference: 'adv:save-theme-preference',
+  advancedSetDataDir: 'adv:set-data-dir',
   advancedClearData: (instanceId: string) => `adv:data-${instanceId}`,
   advancedClearVenv: (instanceId: string) => `adv:venv-${instanceId}`,
   advancedClearPycache: (instanceId: string) => `adv:pycache-${instanceId}`,

--- a/src/pages/Advanced.tsx
+++ b/src/pages/Advanced.tsx
@@ -773,6 +773,7 @@ export default function Advanced() {
         <DataDirMigrationModal
           key={pendingDataDirChange.old_dir + ' | ' + pendingDataDirChange.new_dir}
           change={pendingDataDirChange}
+          onExitFailed={() => setPendingDataDirChange(null)}
         />
       )}
     </>

--- a/src/pages/Advanced.tsx
+++ b/src/pages/Advanced.tsx
@@ -7,7 +7,9 @@ import { SKIP_OPERATION, useOperationRunner } from '../hooks/useOperationRunner'
 import { findLatestOrSkip } from '../hooks/operationGuards';
 import { useLockCheckModal } from '../hooks/useLockCheckModal';
 import { ConfirmModal } from '../components/ConfirmModal';
+import { DataDirMigrationModal } from '../components/DataDirMigrationModal';
 import { GeneralSettingsCard } from '../components/advanced/GeneralSettingsCard';
+import { DataDirSettingsCard } from '../components/advanced/DataDirSettingsCard';
 import { LockCheckConfirmModal } from '../components/LockCheckConfirmModal';
 import { ProxySettingsCard } from '../components/advanced/ProxySettingsCard';
 import { RepairInstanceModal } from '../components/advanced/RepairInstanceModal';
@@ -16,7 +18,7 @@ import { TroubleshootingCard } from '../components/advanced/TroubleshootingCard'
 import { PageHeader } from '../components/PageHeader';
 import { handleApiError } from '../utils';
 import { OPERATION_KEYS } from '../constants';
-import type { RepairPreserveScope, ThemePreference } from '../types';
+import type { DataDirChangeResult, RepairPreserveScope, ThemePreference } from '../types';
 import {
   normalizeInputValue,
   validateGithubProxy,
@@ -63,6 +65,7 @@ export default function Advanced() {
   const config = useAppStore((s) => s.config);
   const components = useAppStore((s) => s.components);
   const loading = useAppStore((s) => s.loading);
+  const dataDir = useAppStore((s) => s.dataDir);
   const reloadSnapshot = useAppStore((s) => s.reloadSnapshot);
   const rebuildSnapshotFromDisk = useAppStore((s) => s.rebuildSnapshotFromDisk);
   const setThemePreference = useAppStore((s) => s.setThemePreference);
@@ -96,6 +99,9 @@ export default function Advanced() {
   // Modal state
   const [confirmModal, setConfirmModal] = useState<ConfirmModalType>(null);
   const [repairModalOpen, setRepairModalOpen] = useState(false);
+  const [pendingDataDirChange, setPendingDataDirChange] = useState<DataDirChangeResult | null>(
+    null
+  );
   const { lockCheckModal, closeLockCheckModal, handleLockCheckError } =
     useLockCheckModal<LockCheckRetryPayload>();
 
@@ -354,6 +360,17 @@ export default function Advanced() {
     });
   };
 
+  const handleSetDataDir = async (newDir: string) => {
+    await runOperation({
+      key: OPERATION_KEYS.advancedSetDataDir,
+      reloadAfter: false,
+      task: () => api.setDataDir(newDir),
+      onSuccess: (result) => {
+        setPendingDataDirChange(result);
+      },
+    });
+  };
+
   const handleClearInstance = async ({
     selectedId,
     operationKey,
@@ -559,6 +576,7 @@ export default function Advanced() {
   const lockCheckExtensionWhitelistSaving =
     operations[OPERATION_KEYS.advancedSaveLockCheckExtensionWhitelist] || false;
   const themePreferenceSaving = operations[OPERATION_KEYS.advancedSaveThemePreference] || false;
+  const dataDirSaving = operations[OPERATION_KEYS.advancedSetDataDir] || false;
   const autostartMinimizeToTraySaving =
     operations[OPERATION_KEYS.advancedSaveAutostartMinimizeToTray] || false;
   const lockCheckModalLoading =
@@ -644,6 +662,12 @@ export default function Advanced() {
         onMainlandAccelerationChange={handleMainlandAccelerationChange}
         onLockCheckExtensionWhitelistChange={handleLockCheckExtensionWhitelistChange}
         onThemePreferenceChange={handleThemePreferenceChange}
+      />
+
+      <DataDirSettingsCard
+        dataDir={dataDir}
+        saving={dataDirSaving}
+        onSetDataDir={handleSetDataDir}
       />
 
       <ProxySettingsCard
@@ -744,6 +768,13 @@ export default function Advanced() {
         onContinue={handleContinueAfterLockCheckFailure}
         onClose={closeLockCheckModal}
       />
+
+      {pendingDataDirChange && (
+        <DataDirMigrationModal
+          key={pendingDataDirChange.old_dir + ' | ' + pendingDataDirChange.new_dir}
+          change={pendingDataDirChange}
+        />
+      )}
     </>
   );
 }

--- a/src/stores/useAppStore.ts
+++ b/src/stores/useAppStore.ts
@@ -25,6 +25,7 @@ interface AppState {
   backups: BackupInfo[];
   components: ComponentStatus[];
   config: AppConfig | null;
+  dataDir: string | null;
   loading: boolean;
   initialized: boolean;
 
@@ -145,6 +146,7 @@ export const useAppStore = create<AppState>((set, get) => {
       backups: snapshot.backups,
       components: nextComponents,
       config: snapshot.config,
+      dataDir: snapshot.data_dir,
       initialized: true,
     });
   };
@@ -182,6 +184,7 @@ export const useAppStore = create<AppState>((set, get) => {
     backups: [],
     components: [],
     config: null,
+    dataDir: null,
     loading: false,
     initialized: false,
     operations: {},

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -68,6 +68,12 @@ export interface AppSnapshot {
   backups: BackupInfo[];
   components: ComponentsSnapshot;
   config: AppConfig;
+  data_dir: string;
+}
+
+export interface DataDirChangeResult {
+  old_dir: string;
+  new_dir: string;
 }
 
 export type InstanceState = 'stopped' | 'starting' | 'running' | 'stopping';


### PR DESCRIPTION
Users can now move the launcher data directory (instances, versions, components, backups) to a custom location via the advanced settings page. The override is stored outside the data directory itself, in the OS config directory, so it survives data migration and app updates.

Changing the directory shows a migration prompt with a forced 3-second wait before the app can be exited, guiding users to move their data manually before restarting.

## Summary by Sourcery

Allow users to configure a custom data directory and surface it in the app snapshot and advanced settings, with a guided migration flow.

New Features:
- Add support for overriding the launcher data directory via advanced settings, persisted in an OS config-backed file and applied across path helpers.
- Expose the current data directory in the app snapshot and UI, including controls to open the folder and change its location.
- Introduce a data directory migration modal that explains manual migration steps, enforces a short confirmation delay, and then exits the app.

Enhancements:
- Centralize launcher-specific config path handling and reuse it for window state persistence.
- Add validation for data directory paths and ensure required data subdirectories are created after changes.

Build:
- Add tauri dialog plugin dependencies to enable native directory selection and folder-opening capabilities.